### PR TITLE
Changes to enable mapping to OrderSourceAPI V2

### DIFF
--- a/src/internal/input.ts
+++ b/src/internal/input.ts
@@ -48,3 +48,4 @@ export { SalesOrderPagingPOJO as SalesOrderPaging } from "../public/orders/sales
 export { URLString } from "../public/common/types";
 export { SalesOrderPackageItemPOJO as SalesOrderPackageItem } from "./orders/shipments/sales-order-package-item";
 export { SalesOrderShipmentPOJO as SalesOrderShipment } from "./orders/shipments/sales-order-shipment";
+export { Country } from "../public/common/country";

--- a/src/internal/orders/order-app.ts
+++ b/src/internal/orders/order-app.ts
@@ -61,7 +61,7 @@ export class OrderApp extends ConnectionApp {
   }
 
   public async getSalesOrdersByDate?(
-    transaction: TransactionPOJO, range: SalesOrderTimeRangePOJO): Promise<SalesOrderArray[]> {
+    transaction: TransactionPOJO, range: SalesOrderTimeRangePOJO): Promise<SalesOrderArray> {
 
     let _transaction, _range;
     const { getSalesOrdersByDate } = this[_private];

--- a/src/internal/orders/sales-order-paging.ts
+++ b/src/internal/orders/sales-order-paging.ts
@@ -23,6 +23,7 @@ export class SalesOrderPaging {
     this.pageNumber = pojo.pageNumber || 0;
     this.pageCount = pojo.pageCount || 0;
     this.cursor = pojo.cursor || "";
+    
     // Make this object immutable
     hideAndFreeze(this);
   }

--- a/src/internal/orders/sales-order-time-range.ts
+++ b/src/internal/orders/sales-order-time-range.ts
@@ -3,7 +3,7 @@ import { hideAndFreeze, Joi, TimeRange, TimeRangeBase, _internal } from "../comm
 
 
 export interface SalesOrderTimeRangePOJO extends TimeRangePOJO {
-  paging: SalesOrderPaging;
+  paging?: SalesOrderPaging;
 }
 
 
@@ -30,7 +30,11 @@ export class SalesOrderTimeRange extends TimeRangeBase implements ISalesOrderTim
   public constructor(pojo: SalesOrderTimeRangePOJO) {
     super(pojo);
 
-    this.paging = pojo.paging;
+    // TODO How do we want to build the initial paging data?
+    this.paging = pojo.paging || {
+      pageCount: 0,
+      pageSize: 0,
+    };
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/internal/orders/sales-order-time-range.ts
+++ b/src/internal/orders/sales-order-time-range.ts
@@ -1,9 +1,10 @@
-import { SalesOrderPaging, SalesOrderTimeRange as ISalesOrderTimeRange, TimeRangePOJO } from "../../public";
+import { SalesOrderPaging as SalesOrderPagingPOJO, SalesOrderTimeRange as ISalesOrderTimeRange, TimeRangePOJO } from "../../public";
 import { hideAndFreeze, Joi, TimeRange, TimeRangeBase, _internal } from "../common";
+import { SalesOrderPaging } from "./sales-order-paging";
 
 
 export interface SalesOrderTimeRangePOJO extends TimeRangePOJO {
-  paging?: SalesOrderPaging;
+  paging?: SalesOrderPagingPOJO;
 }
 
 
@@ -11,16 +12,13 @@ export class SalesOrderTimeRange extends TimeRangeBase implements ISalesOrderTim
   public static readonly [_internal] = {
     label: "time range",
     schema: TimeRange[_internal].schema.keys({
-      paging: Joi.object({
-        pageSize: Joi.number().integer().min(1).required(),
-        pageNumber: Joi.number().integer().min(0),
-        pageCount: Joi.number().integer().min(1),
-        cursor: Joi.string()
-      })
+      paging: SalesOrderPaging[_internal].schema
     })
   };
 
-  public readonly paging: {
+  // TODO: make this optional because the first request won't always be populated since it needs to 
+  // be populated by the app user.
+  public readonly paging?: {
     readonly pageSize: number;
     readonly pageNumber?: number;
     readonly pageCount: number;
@@ -30,11 +28,9 @@ export class SalesOrderTimeRange extends TimeRangeBase implements ISalesOrderTim
   public constructor(pojo: SalesOrderTimeRangePOJO) {
     super(pojo);
 
-    // TODO How do we want to build the initial paging data?
-    this.paging = pojo.paging || {
-      pageCount: 0,
-      pageSize: 0,
-    };
+    if(pojo.paging) {
+      this.paging = new SalesOrderPaging(pojo.paging);
+    }
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/internal/output.ts
+++ b/src/internal/output.ts
@@ -38,3 +38,4 @@ export { ShippingPreferences } from "./orders/shipping-preferences";
 export { SalesOrder } from "./orders/sales-order";
 export { SalesOrderArray } from "./orders/sales-order-array";
 export { SalesOrderPaging } from "./orders/sales-order-paging";
+export { PersonName } from "./common/addresses/person-name"

--- a/src/public/orders/sales-order-time-range.ts
+++ b/src/public/orders/sales-order-time-range.ts
@@ -5,7 +5,7 @@ import type { TimeRange } from "../common";
  * Specifies a date/time range to retrieve sales orders for
  */
 export interface SalesOrderTimeRange extends TimeRange {
-  readonly paging: Readonly<SalesOrderPaging>;
+  readonly paging?: Readonly<SalesOrderPaging>;
 }
 
 


### PR DESCRIPTION
There were a few types I needed to access via `Input` or `Output` that weren't being exported.

Also, `SalesOrderTimeRangePOJO` required a `paging` to always be attached, but the platform won't populate a value for this on the 1st request of a batch, so we need to supply a default case or make it `?` all the way into the function API.