### PR TITLE
Error normalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -396,11 +396,6 @@
         "@qawolf/ci-info": "^2.1.0"
       }
     },
-    "@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
     "@jsdevtools/readdir-enhanced": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@jsdevtools/readdir-enhanced/-/readdir-enhanced-6.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "@jsdevtools/ono": "^7.1.3",
     "@types/json-schema": "^7.0.6",
     "@types/react-jsonschema-form": "^1.7.4",
     "currency.js": "^2.0.2",

--- a/src/internal/carriers/carrier-app.ts
+++ b/src/internal/carriers/carrier-app.ts
@@ -1,5 +1,5 @@
 import { AppType, CancellationStatus, CancelPickups, CancelShipments, CarrierAppDefinition, Connect, Country, CreateManifest, CreateShipment, DocumentFormat, DocumentSize, ErrorCode, ManifestLocation, ManifestShipment, ManifestType, Packaging, RateShipment, SchedulePickup, ServiceArea, TrackShipment } from "../../public";
-import { AppPOJO, ConnectionApp, error, FormPOJO, hideAndFreeze, Joi, Transaction, TransactionPOJO, validate, validateArray, _internal } from "../common";
+import { AppPOJO, ConnectionApp, error, FormPOJO, hideAndFreeze, Joi, SystemErrorCode, Transaction, TransactionPOJO, validate, validateArray, _internal } from "../common";
 import { DeliveryConfirmation } from "./delivery-confirmation";
 import { DeliveryService, DeliveryServicePOJO } from "./delivery-service";
 import { ManifestConfirmation } from "./manifests/manifest-confirmation";
@@ -223,18 +223,17 @@ export class CarrierApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
       _shipment = new NewShipment(validate(shipment, NewShipment), this);
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the createShipment method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the createShipment method.", { originalError });
     }
 
     try {
       const confirmation = await createShipment!(_transaction, _shipment);
       return new ShipmentConfirmation(validate(confirmation, ShipmentConfirmation));
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-
-      throw error((originalError.code || ErrorCode.AppError), "Error in the createShipment method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the createShipment method.", { originalError, transactionID });
     }
   }
 
@@ -249,8 +248,8 @@ export class CarrierApp extends ConnectionApp {
       _shipments = validateArray(shipments, ShipmentCancellation)
         .map((shipment) => new ShipmentCancellation(shipment));
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the cancelShipments method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the cancelShipments method.", { originalError });
     }
 
     try {
@@ -267,10 +266,9 @@ export class CarrierApp extends ConnectionApp {
       return validateArray(confirmations, ShipmentCancellationOutcome)
         .map((confirmation) => new ShipmentCancellationOutcome(confirmation));
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-
-      throw error((originalError.code || ErrorCode.AppError), "Error in the cancelShipments method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the cancelShipments method.", { originalError, transactionID });
     }
   }
 
@@ -284,18 +282,17 @@ export class CarrierApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
       _shipment = new RateCriteria(validate(shipment, RateCriteria), this);
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the rateShipment method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the rateShipment method.", { originalError });
     }
 
     try {
       const rates = await rateShipment!(_transaction, _shipment);
       return validateArray(rates, Rate).map((rate) => new Rate(rate, this));
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-
-      throw error((originalError.code || ErrorCode.AppError), "Error in the rateShipment method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the rateShipment method.", { originalError, transactionID });
     }
   }
 
@@ -309,18 +306,17 @@ export class CarrierApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
       _shipment = new TrackingCriteria(validate(shipment, TrackingCriteria));
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the trackShipment method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the trackShipment method.", { originalError });
     }
 
     try {
       const trackingInfo = await trackShipment!(_transaction, _shipment);
       return new TrackingInfo(validate(trackingInfo, TrackingInfo), this);
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-
-      throw error((originalError.code || ErrorCode.AppError), "Error in the trackShipment method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the trackShipment method.", { originalError, transactionID });
     }
   }
 
@@ -334,18 +330,17 @@ export class CarrierApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
       _manifest = new NewManifest(validate(manifest, NewManifest), this);
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the createManifest method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the createManifest method.", { originalError });
     }
 
     try {
       const confirmation = await createManifest!(_transaction, _manifest);
       return new ManifestConfirmation(validate(confirmation, ManifestConfirmation));
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-
-      throw error((originalError.code || ErrorCode.AppError), "Error in the createManifest method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the createManifest method.", { originalError, transactionID });
     }
   }
 
@@ -359,8 +354,8 @@ export class CarrierApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
       _pickup = new PickupRequest(validate(pickup, PickupRequest), this);
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the schedulePickup method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the schedulePickup method.", { originalError });
     }
 
     try {
@@ -373,10 +368,9 @@ export class CarrierApp extends ConnectionApp {
 
       return new PickupConfirmation(validate(confirmation, PickupConfirmation));
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-
-      throw error((originalError.code || ErrorCode.AppError), "Error in the schedulePickup method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the schedulePickup method.", { originalError, transactionID });
     }
   }
 
@@ -390,8 +384,8 @@ export class CarrierApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
       _pickups = validateArray(pickups, PickupCancellation).map((pickup) => new PickupCancellation(pickup, this));
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the cancelPickups method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the cancelPickups method.", { originalError });
     }
 
     try {
@@ -408,10 +402,9 @@ export class CarrierApp extends ConnectionApp {
       return validateArray(confirmations, PickupCancellationOutcome)
         .map((confirmation) => new PickupCancellationOutcome(confirmation));
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-
-      throw error((originalError.code || ErrorCode.AppError), "Error in the cancelPickups method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the cancelPickups method.", { originalError, transactionID });
     }
   }
 

--- a/src/internal/carriers/documents/document.ts
+++ b/src/internal/carriers/documents/document.ts
@@ -16,7 +16,7 @@ export abstract class DocumentBase {
     this.data = pojo.data;
 
     if (this.data.length === 0) {
-      throw error(ErrorCode.Validation, `${this.name} data cannot be empty`);
+      throw error(ErrorCode.Invalid, `${this.name} data cannot be empty`);
     }
   }
 }

--- a/src/internal/carriers/manifests/new-manifest.ts
+++ b/src/internal/carriers/manifests/new-manifest.ts
@@ -37,7 +37,7 @@ export class NewManifest implements INewManifest {
     switch (carrier.manifestLocations) {
       case ManifestLocation.AllLocations:
         if (pojo.shipFrom) {
-          throw error(ErrorCode.Validation,
+          throw error(ErrorCode.Invalid,
             `manifest.shipFrom is not allowed because carrier.manifestLocations is ${ManifestLocation.AllLocations}`);
         }
         break;
@@ -45,7 +45,7 @@ export class NewManifest implements INewManifest {
       case ManifestLocation.SingleLocation:
       default:
         if (!pojo.shipFrom) {
-          throw error(ErrorCode.Validation,
+          throw error(ErrorCode.Invalid,
             `manifest.shipFrom is required because carrier.manifestLocations is ${ManifestLocation.SingleLocation}`);
         }
     }

--- a/src/internal/carriers/utils.ts
+++ b/src/internal/carriers/utils.ts
@@ -1,5 +1,5 @@
-import { ErrorCode, ServiceArea, AppError } from "../../public";
-import { error, MonetaryValue } from "../common";
+import { AppError, ServiceArea } from "../../public";
+import { error, MonetaryValue, SystemErrorCode } from "../common";
 
 
 /**
@@ -47,11 +47,11 @@ export function calculateTotalInsuranceAmount(packages: ReadonlyArray<{ insuredV
       return MonetaryValue.sum(insuredValues);
     }
   }
-  catch (originalError) {
+  catch (originalError: unknown) {
     // Check for a currency mismatch, and throw a more specific error message
-    if ((originalError as AppError).code === ErrorCode.CurrencyMismatch) {
+    if ((originalError as AppError).code === SystemErrorCode.CurrencyMismatch) {
       throw error(
-        ErrorCode.CurrencyMismatch,
+        SystemErrorCode.CurrencyMismatch,
         "All packages in a shipment must be insured in the same currency.",
         { originalError }
       );

--- a/src/internal/common/charge.ts
+++ b/src/internal/common/charge.ts
@@ -1,5 +1,5 @@
-import { Charge as ICharge, ChargePOJO, ChargeType, ErrorCode, AppError } from "../../public";
-import { error } from "./errors";
+import { AppError, Charge as ICharge, ChargePOJO, ChargeType } from "../../public";
+import { error, SystemErrorCode } from "./errors";
 import { MonetaryValue } from "./measures/monetary-value";
 import { hideAndFreeze, _internal } from "./utils";
 import { Joi } from "./validation";
@@ -13,11 +13,11 @@ export function calculateTotalCharges(charges: readonly Charge[]): MonetaryValue
     const insuredValues = charges.map((charge) => charge.amount);
     return MonetaryValue.sum(insuredValues);
   }
-  catch (originalError) {
+  catch (originalError: unknown) {
     // Check for a currency mismatch, and throw a more specific error message
-    if ((originalError as AppError).code === ErrorCode.CurrencyMismatch) {
+    if ((originalError as AppError).code === SystemErrorCode.CurrencyMismatch) {
       throw error(
-        ErrorCode.CurrencyMismatch,
+        SystemErrorCode.CurrencyMismatch,
         "All charges must be in the same currency.",
         { originalError }
       );

--- a/src/internal/common/connection-app.ts
+++ b/src/internal/common/connection-app.ts
@@ -1,6 +1,6 @@
 import { Connect, ConnectionAppDefinition, ErrorCode, FilePath } from "../../public";
 import { App, AppPOJO } from "./app";
-import { error } from "./errors";
+import { error, SystemErrorCode } from "./errors";
 import { Form, FormPOJO } from "./form";
 import { Transaction, TransactionPOJO } from "./transaction";
 import { _internal } from "./utils";
@@ -67,16 +67,16 @@ export abstract class ConnectionApp extends App {
       _transaction = new Transaction(validate(transaction, Transaction));
       _connectionFormData = Object.assign({}, connectionFormData);
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the connect method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the connect method.", { originalError });
     }
 
     try {
       await connect!(_transaction, _connectionFormData);
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-      throw error((originalError.code || ErrorCode.AppError), "Error in the connect method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the connect method.", { originalError, transactionID });
     }
   }
 }

--- a/src/internal/common/errors.ts
+++ b/src/internal/common/errors.ts
@@ -2,6 +2,15 @@ import { ono } from "@jsdevtools/ono";
 import { ErrorCode, AppError, UUID } from "../../public";
 
 /**
+ * Error codes for ShipEngine Connect SDK runtime errors
+ */
+export enum SystemErrorCode {
+  InvalidInput = "ERR_INVALID_INPUT",
+  CurrencyMismatch = "ERR_CURRENCY_MISMATCH",
+}
+
+
+/**
  * Additional properties to add to a an error
  */
 export interface ErrorProps {
@@ -9,6 +18,7 @@ export interface ErrorProps {
   transactionID?: UUID;
   [key: string]: unknown;
 }
+
 
 /**
  * Creates a ShipEngine Connect SDK error

--- a/src/internal/common/errors.ts
+++ b/src/internal/common/errors.ts
@@ -1,4 +1,4 @@
-import { AppError, ErrorCode, UUID } from "../../public";
+import { ErrorCode, UUID } from "../../public";
 
 /**
  * Error codes for ShipEngine Connect SDK runtime errors
@@ -6,6 +6,17 @@ import { AppError, ErrorCode, UUID } from "../../public";
 export enum SystemErrorCode {
   InvalidInput = "ERR_INVALID_INPUT",
   CurrencyMismatch = "ERR_CURRENCY_MISMATCH",
+}
+
+
+/**
+ * An error thrown by the ShipEngine Connect SDK
+ */
+export interface SystemError extends Error {
+  code: ErrorCode | SystemErrorCode;
+  transactionID?: UUID;
+  originalError?: Error;
+  [key: string]: unknown;
 }
 
 
@@ -22,14 +33,14 @@ export interface ErrorProps {
 /**
  * Creates a ShipEngine Connect SDK error
  */
-export function error(code: ErrorCode | SystemErrorCode, message: string, props: ErrorProps = {}): AppError {
-  let originalError = props.originalError as AppError | undefined;
+export function error(code: ErrorCode | SystemErrorCode, message: string, props: ErrorProps = {}): SystemError {
+  let originalError = props.originalError as SystemError | undefined;
 
   if (originalError) {
     message += ` \n${originalError.message}`;
   }
 
-  const error = new Error(message) as AppError;
+  const error = new Error(message) as SystemError;
 
   // Copy all props from the original error and the user-specified props
   Object.assign(error, originalError, props);
@@ -40,7 +51,7 @@ export function error(code: ErrorCode | SystemErrorCode, message: string, props:
 
   // Set the original error to the TRUE original error
   while (originalError && originalError.originalError) {
-    error.originalError = originalError = originalError.originalError as AppError;
+    error.originalError = originalError = originalError.originalError as SystemError;
   }
 
   return error;

--- a/src/internal/common/measures/monetary-value.ts
+++ b/src/internal/common/measures/monetary-value.ts
@@ -1,6 +1,6 @@
 import * as currency from "currency.js";
-import { ErrorCode, MonetaryValue as IMonetaryValue, MonetaryValuePOJO } from "../../../public";
-import { error } from "../errors";
+import { MonetaryValue as IMonetaryValue, MonetaryValuePOJO } from "../../../public";
+import { error, SystemErrorCode } from "../errors";
 import { hideAndFreeze, _internal } from "../utils";
 import { Joi } from "../validation";
 
@@ -46,7 +46,7 @@ export class MonetaryValue implements IMonetaryValue {
     if (uniqueCurrencies.size > 1) {
       const currencies = [...uniqueCurrencies];
       throw error(
-        ErrorCode.CurrencyMismatch,
+        SystemErrorCode.CurrencyMismatch,
         `Currency mismatch: ${currencies.join(", ")}. All monetary values must be in the same currency.`,
         { currencies }
       );

--- a/src/internal/common/measures/time-range.ts
+++ b/src/internal/common/measures/time-range.ts
@@ -14,7 +14,7 @@ export abstract class TimeRangeBase implements ITimeRange {
 
     if (this.startDateTime && this.endDateTime) {
       if (this.endDateTime.getTime() < this.startDateTime.getTime()) {
-        throw error(ErrorCode.Validation,
+        throw error(ErrorCode.Invalid,
           `Invalid time range: ${this.toString()}. The start date occurs after the end date.`);
       }
     }

--- a/src/internal/common/reference-map.ts
+++ b/src/internal/common/reference-map.ts
@@ -37,13 +37,13 @@ export class ReferenceMap {
       // We already have a reference to this instance. Just make sure the types match.
       if (existing.type !== type) {
         // There are two different objects with the same UUID
-        throw error(ErrorCode.Validation, `Duplicate UUID: ${instance.id}`);
+        throw error(ErrorCode.Invalid, `Duplicate UUID: ${instance.id}`);
       }
     }
     else {
       if (isFinishedLoading) {
         // The app has already finished loading, so no new objects can be added.
-        throw error(ErrorCode.Validation, `Cannot add new ${type[_internal].label} after the app has loaded`);
+        throw error(ErrorCode.Invalid, `Cannot add new ${type[_internal].label} after the app has loaded`);
       }
 
       // Certain definitions need to be referenced by their code identifier rather than their GUID ID.
@@ -74,7 +74,7 @@ export class ReferenceMap {
     if (typeof instance === "string") {
       reference = map.get(instance);
       if (reference && reference.type !== type) {
-        throw error(ErrorCode.Validation,
+        throw error(ErrorCode.Invalid,
           `${instance} is a ${reference.type[_internal].label} not a ${type[_internal].label}`);
       }
     }
@@ -82,7 +82,7 @@ export class ReferenceMap {
       validate(instance, type[_internal].label, classInstanceSchema);
       reference = map.get(instance.id);
       if (reference && reference.type !== type) {
-        throw error(ErrorCode.Validation,
+        throw error(ErrorCode.Invalid,
           `${instance.id} is a ${reference.type[_internal].label} ID not a ${type[_internal].label} ID`);
       }
     }
@@ -108,10 +108,10 @@ export class ReferenceMap {
 
     if (!value) {
       if (typeof instance === "string") {
-        throw error(ErrorCode.Validation, `Unable to find ${type[_internal].label}: ${instance}`);
+        throw error(ErrorCode.Invalid, `Unable to find ${type[_internal].label}: ${instance}`);
       }
       else {
-        throw error(ErrorCode.Validation, `Unable to find ${type[_internal].label} ID: ${instance.id}`);
+        throw error(ErrorCode.Invalid, `Unable to find ${type[_internal].label} ID: ${instance.id}`);
       }
     }
 

--- a/src/internal/common/validation/index.ts
+++ b/src/internal/common/validation/index.ts
@@ -52,14 +52,14 @@ export function validate<T>(value: T, arg2: ShipEngineConstructor | string, arg3
  */
 function validateAgainstSchema(value: unknown, label: string, schema: ValidationSchema): void {
   if (value === undefined || value === null) {
-    throw error(ErrorCode.Validation, `Invalid ${label}: \n  A value is required`);
+    throw error(ErrorCode.Invalid, `Invalid ${label}: \n  A value is required`);
   }
 
   const result = schema.validate(value, joiOptions as joi.ValidationOptions);
 
   if (result.error) {
     throw error(
-      ErrorCode.Validation,
+      ErrorCode.Invalid,
       `Invalid ${label}: \n  ` + result.error.details.map((detail) => detail.message).join(" \n  "),
       {
         details: result.error.details

--- a/src/internal/orders/order-app.ts
+++ b/src/internal/orders/order-app.ts
@@ -1,11 +1,10 @@
-import { AppType, Connect, ErrorCode, GetSalesOrdersByDate, OrderAppDefinition, ShipmentCreated, AcknowledgeOrders } from "../../public";
-import { AppPOJO, ConnectionApp, error, FormPOJO, hideAndFreeze, Joi, Transaction, TransactionPOJO, validate, _internal } from "../common";
-import { SalesOrderTimeRange, SalesOrderTimeRangePOJO } from "./sales-order-time-range";
-import { SalesOrderShipment, SalesOrderShipmentPOJO } from "./shipments/sales-order-shipment";
-import { SalesOrders } from "./sales-orders";
-import { SalesOrders as SalesOrdersPOJO } from "../../public";
+import { AcknowledgeOrders, AppType, Connect, ErrorCode, GetSalesOrdersByDate, OrderAppDefinition, SalesOrders as SalesOrdersPOJO, ShipmentCreated } from "../../public";
+import { AppPOJO, ConnectionApp, error, FormPOJO, hideAndFreeze, Joi, SystemErrorCode, Transaction, TransactionPOJO, validate, _internal } from "../common";
 import { AcknowledgedSalesOrder } from "./acknowledged-sales-order";
 import { SalesOrderNotification, SalesOrderNotificationPOJO } from "./sales-order-notification";
+import { SalesOrderTimeRange, SalesOrderTimeRangePOJO } from "./sales-order-time-range";
+import { SalesOrders } from "./sales-orders";
+import { SalesOrderShipment, SalesOrderShipmentPOJO } from "./shipments/sales-order-shipment";
 
 const _private = Symbol("private fields");
 
@@ -76,8 +75,8 @@ export class OrderApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
       _range = new SalesOrderTimeRange(validate(range, SalesOrderTimeRange));
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the getSalesOrdersByDate method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the getSalesOrdersByDate method.", { originalError });
     }
 
     try {
@@ -91,9 +90,9 @@ export class OrderApp extends ConnectionApp {
 
       return new SalesOrders(salesOrderArrayPOJO);
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-      throw error((originalError.code || ErrorCode.AppError), "Error in the getSalesOrdersByDate method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the getSalesOrdersByDate method.", { originalError, transactionID });
     }
   }
 
@@ -105,16 +104,16 @@ export class OrderApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
       _shipment = new SalesOrderShipment(validate(shipment, SalesOrderShipment));
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the shipmentCreated method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the shipmentCreated method.", { originalError });
     }
 
     try {
       await shipmentCreated!(_transaction, _shipment);
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-      throw error((originalError.code || ErrorCode.AppError), "Error in the shipmentCreated method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the shipmentCreated method.", { originalError, transactionID });
     }
   }
 
@@ -127,15 +126,15 @@ export class OrderApp extends ConnectionApp {
       _transaction = new Transaction(validate(transaction, Transaction));
 
       if(notifications.length === 0) {
-        throw error (ErrorCode.InvalidInput, "Sales Order Notifications are required");
+        throw error (SystemErrorCode.InvalidInput, "Sales Order Notifications are required");
       }
 
       for(const notification of notifications) {
         _notifications.push(new SalesOrderNotification(validate(notification, SalesOrderNotification)));
       }
     }
-    catch (originalError) {
-      throw error(ErrorCode.InvalidInput, "Invalid input to the acknowledgeOrders method.", { originalError });
+    catch (originalError: unknown) {
+      throw error(SystemErrorCode.InvalidInput, "Invalid input to the acknowledgeOrders method.", { originalError });
     }
 
     try {
@@ -148,9 +147,9 @@ export class OrderApp extends ConnectionApp {
 
       return acknowledgedOrders;
     }
-    catch (originalError) {
+    catch (originalError: unknown) {
       const transactionID = _transaction.id;
-      throw error((originalError.code || ErrorCode.AppError), "Error in the acknowledgeOrders method.", { originalError, transactionID });
+      throw error(ErrorCode.AppError, "Error in the acknowledgeOrders method.", { originalError, transactionID });
     }
   }
 }

--- a/src/public/common/errors.ts
+++ b/src/public/common/errors.ts
@@ -4,10 +4,8 @@
 export enum ErrorCode {
   AppError = "ERR_APP_ERROR",
   BadRequest = "ERR_BAD_REQUEST",
-  CurrencyMismatch = "ERR_CURRENCY_MISMATCH",
   ExternalServiceError = "ERR_EXTERNAL_SERVICE_ERROR",
   Filesystem = "ERR_FILESYSTEM",
-  InvalidInput = "ERR_INVALID_INPUT",
   NotFound = "ERR_NOT_FOUND",
   RateLimit = "ERR_RATE_LIMIT",
   Syntax = "ERR_SYNTAX",

--- a/src/public/common/errors.ts
+++ b/src/public/common/errors.ts
@@ -1,227 +1,153 @@
+import { UUID } from "./types";
+
 /**
  * Error codes for ShipEngine Connect SDK runtime errors
  */
 export enum ErrorCode {
   AppError = "ERR_APP_ERROR",
-  BadRequest = "ERR_BAD_REQUEST",
-  ExternalServiceError = "ERR_EXTERNAL_SERVICE_ERROR",
-  Filesystem = "ERR_FILESYSTEM",
-  NotFound = "ERR_NOT_FOUND",
-  RateLimit = "ERR_RATE_LIMIT",
-  Syntax = "ERR_SYNTAX",
+  Invalid = "ERR_INVALID",
   Unauthorized = "ERR_UNAUTHORIZED",
-  Validation = "ERR_INVALID",
+  External = "ERR_EXTERNAL",
 }
+
 
 /**
- * This method is used to create field errors which are used in various errors.
- *
- * @param {string} attemptedValue The value the user supplied.
- * @param {string} errorCode An error code if one is applicable.
- * @param {string} errorMessage The useful error message to return to the user.
- * @param {string} fieldName The name of the field that is failing to validate.
+ * An error that is thrown by a ShipEngine Connect app
  */
-export interface FieldError {
-  attemptedValue?: string;
-  errorCode?: string;
-  errorMessage?: string;
-  fieldName?: string;
-}
-
-export enum ErrorSource {
-  External = "external",
-  Internal = "internal",
-}
-
 export interface AppError extends Error {
-  code: ErrorCode;
-  message: string;
-  canBeRetried?: boolean;
-  originalError?: Error;
-  source?: ErrorSource;
+  code: ErrorCode | string;
   statusCode?: number;
-  transactionID?: string;
+  transactionID?: UUID;
+  originalError?: Error;
+  [key: string]: unknown;
 }
+
 
 /**
- * Normalize error args and apply defaults
+ * The arguments that can be passsed to a ShipEngine Connect error constructor.
  */
-function normalizeArgs<T extends AppError>(args: string | T): AppError {
-  if (typeof args === "string") {
-    return {
-      message: args,
-      code: ErrorCode.AppError,
-    } as T;
-  }
-  else {
-    return args;
-  }
+export interface AppErrorArgs {
+  /**
+   * The error message.
+   */
+  message: string
+
+  /**
+   * The numeric status code associated with the error, if any.
+   * For errors that originate from an HTTP request, this should be the HTTP status code
+   * (e.g. 400, 404, 500, etc.)
+   */
+  statusCode?: number;
+
+  /**
+   * The original error that occurred, if this is a re-thrown error.
+   */
+  originalError?: Error;
+
+  /**
+   * Additional arbitrary properties that provide more information or context about the error.
+   */
+  [key: string]: unknown;
 }
 
-abstract class BaseError extends Error implements AppError {
-  public code: ErrorCode;
-  public source?: ErrorSource;
-  public statusCode?: number;
-  public canBeRetried?: boolean;
-  public originalError?: Error;
-  public transactionID?: string;
 
-  public constructor(args: AppError) {
+/**
+ * An error that is thrown by a ShipEngine Connect app
+ */
+export class AppError extends Error implements AppError {
+  public code: string;
+  public statusCode?: number;
+  public transactionID?: UUID;
+  public originalError?: Error;
+
+  /**
+   * @param args
+   * The error message, or an object with a message and other properties to assign to the error
+   */
+  public constructor(args: string | AppErrorArgs) {
+    args = normalizeArgs(args);
     super(args.message);
 
-    // Since this attribute is required tsc requires that it is set explicitly
-    this.code = args.code;
+    // Copy all props to the error
+    Object.assign(this, args.originalError, args);
 
-    Object.assign(this, args);
+    // Don't allow these properties to be overridden
+    this.code = ErrorCode.AppError;
+    this.name = new.target.name;
   }
 }
 
-interface BadRequestErrorArgs extends AppError {
-  fieldErrors?: FieldError[];
-}
 
 /**
- * A Bad Request Error.
- *
- * @param {Error} args.originalError The original error if one exist.
- * @param {FieldError[]} args.fieldErrors An array of objects created by the CreateFieldError function.
- * @param {string} args.message The message that needs to be communicated to the users.
- * @param {string} args.transactionID The transaction ID associated with the function call.
+ * An error indicating that input data is invalid or does not comply with business rules.
  */
-export class BadRequestError extends BaseError {
-  public fieldErrors?: FieldError[];
-
-  public constructor(args: string | BadRequestErrorArgs) {
-    super({
-      // Overridable Defaults
-      canBeRetried: false,
-      source: ErrorSource.External,
-      statusCode: 400,
-
-      // User-specified values override defaults
-      ...normalizeArgs(args),
-
-      // Static Defaults
-      code: ErrorCode.BadRequest,
-      name: "BadRequestError",
-    });
+export class ValidationError extends AppError {
+  /**
+   * @param args
+   * The error message, or an object with a message and other properties to assign to the error
+   */
+  public constructor(args: string | AppErrorArgs) {
+    super(args);
+    this.code = ErrorCode.Invalid;
   }
 }
+
 
 /**
- * An Unauthorized Error.
- *
- * @param {Error} args.originalError The original error if one exist.
- * @param {string} args.message The message that needs to be communicated to the users.
- * @param {string} args.transactionID The transaction ID associated with the function call.
+ * An error indicating that the user is unauthorized or not permitted to perform the requested action.
  */
-export class UnauthorizedError extends BaseError {
-  public constructor(args: string | AppError) {
-    super({
-      // Overridable Defaults
-      canBeRetried: false,
-      source: ErrorSource.External,
-      statusCode: 401,
-
-      // User-specified values override defaults
-      ...normalizeArgs(args),
-
-      // Static Defaults
-      code: ErrorCode.Unauthorized,
-      name: "UnauthorizedError",
-    });
+export class UnauthorizedError extends AppError {
+  /**
+   * @param args
+   * The error message, or an object with a message and other properties to assign to the error
+   */
+  public constructor(args: string | AppErrorArgs) {
+    super(args);
+    this.code = ErrorCode.Unauthorized;
   }
 }
+
 
 /**
- * A Resource Not Found Error.
- *
- * @param {Error} args.originalError The original error if one exist.
- * @param {string} args.message The message that needs to be communicated to the users.
- * @param {string} args.transactionID The transaction ID associated with the function call.
+ * The arguments that can be passsed to the `ExternalError` constructor.
  */
-export class NotFoundError extends BaseError {
-
-  public constructor(args: string | AppError) {
-    super({
-      // Overridable Defaults
-      canBeRetried: false,
-      source: ErrorSource.External,
-      statusCode: 404,
-
-      // User-specified values override defaults
-      ...normalizeArgs(args),
-
-      // Static Defaults
-      code: ErrorCode.NotFound,
-      name: "NotFoundError",
-    });
-  }
-}
-
-interface RateLimitErrorArgs extends AppError {
-  retryInMilliseconds?: number;
-}
-
-/**
- * A Rate Limit Error.
- *
- * @param {Error} args.originalError The original error if one exist.
- * @param {number} args.retryInMilliseconds The number of milliseconds until the request can be retried.
- * @param {string} args.message The message that needs to be communicated to the users.
- * @param {string} args.transactionID The transaction ID associated with the function call.
- */
-export class RateLimitError extends BaseError {
-  public retryInMilliseconds?: number;
-
-  public constructor(args: string | RateLimitErrorArgs) {
-    super({
-      // Overridable Defaults
-      canBeRetried: true,
-      source: ErrorSource.External,
-      statusCode: 429,
-
-      // User-specified values override defaults
-      ...normalizeArgs(args),
-
-      // Static Defaults
-      code: ErrorCode.RateLimit,
-      name: "RateLimitError",
-    });
-  }
-}
-
-interface ExternalServiceErrorArgs extends AppError {
+export interface ExternalErrorArgs extends AppErrorArgs {
+  /**
+   * If the external service returned one or more error messages, put them here.
+   */
   externalErrors?: string[];
+
+  /**
+   * If the external service returned one or more warning messages, put them here.
+   */
   externalWarnings?: string[];
 }
 
+
 /**
- * An External Service Error Error.
- *
- * @param {Error} args.originalError The original error if one exist.
- * @param {string[]} externalErrors An array of errors from the outside world.
- * @param {string[]} externalWarnings An array of warnings from the outside world.
- * @param {string} args.message The message that needs to be communicated to the users.
- * @param {string} args.transactionID The transaction ID associated with the function call.
+ * An error that originated from an external service, such as an API call.
  */
-export class ExternalServiceError extends BaseError {
-  public externalErrors?: string[];
-  public externalWarnings?: string[];
+export class ExternalError extends AppError {
+  public externalErrors!: string[];
+  public externalWarnings!: string[];
 
-  public constructor(args: string | ExternalServiceErrorArgs) {
-    super({
-      // Overridable Defaults
-      canBeRetried: true,
-      source: ErrorSource.External,
-      statusCode: 520,
+  public constructor(args: string | ExternalErrorArgs) {
+    super(args);
+    this.externalErrors = this.externalErrors || [];
+    this.externalWarnings = this.externalWarnings || [];
+    this.code = ErrorCode.External;
+  }
+}
 
-      // User-specified values override defaults
-      ...normalizeArgs(args),
 
-      // Static Defaults
-      code: ErrorCode.ExternalServiceError,
-      name: "RateLimitError",
-    });
+/**
+ * Normalizes the arguments that are passed to an error's constructor
+ */
+function normalizeArgs<T extends AppErrorArgs>(args: string | T): T {
+  if (typeof args === "string") {
+    return { message: args } as T;
+  }
+  else {
+    return args;
   }
 }

--- a/test/specs/common/errors.spec.js
+++ b/test/specs/common/errors.spec.js
@@ -1,9 +1,9 @@
 "use strict";
 
+const { AppError, ValidationError, UnauthorizedError, ExternalError } = require("../../../");
 const { CarrierApp } = require("../../../lib/internal");
 const pojo = require("../../utils/pojo");
 const { assert, expect } = require("chai");
-const ShipEngineErrors = require("../../../lib/public/common/index");
 
 describe("Errors", () => {
   /**
@@ -17,11 +17,19 @@ describe("Errors", () => {
     error.transactionID && expect(error.transactionID).to.be.a("string").with.length.above(0);
 
     // Validate that the error matches the expected values
-    expect(error.toJSON()).to.deep.equal({
-      ...expected,
-      name: error.name,
-      stack: error.stack,
-    });
+    for (const [key, value] of Object.entries(expected)) {
+      if (key === "originalError") continue;
+      expect(error[key]).to.deep.equal(value, `error.${key}`);
+    }
+
+    // Validate the original error, if any
+    if (error.originalError || expected.originalError) {
+      expect(error.originalError).to.be.an.instanceOf(Error, "error.origianlError");
+      expect(expected.originalError).to.be.an("object", "error.origianlError");
+      for (const [key, value] of Object.entries(expected.originalError)) {
+        expect(error.originalError[key]).to.deep.equal(value, `error.originalError.${key}`);
+      }
+    }
   }
 
   it("should throw a validation error", () => {
@@ -32,6 +40,7 @@ describe("Errors", () => {
     }
     catch (error) {
       validateShipEngineError(error, {
+        name: "Error",
         code: "ERR_INVALID",
         message:
           "Invalid ShipEngine Connect carrier app: \n" +
@@ -48,6 +57,7 @@ describe("Errors", () => {
     }
     catch (error) {
       validateShipEngineError(error, {
+        name: "Error",
         code: "ERR_INVALID",
         message:
           "Invalid ShipEngine Connect carrier app: \n" +
@@ -79,11 +89,19 @@ describe("Errors", () => {
     }
     catch (error) {
       validateShipEngineError(error, {
+        name: "Error",
         code: "ERR_INVALID_INPUT",
         message:
           "Invalid input to the createShipment method. \n" +
           "Invalid transaction: \n" +
           "  A value is required",
+        originalError: {
+          name: "Error",
+          code: "ERR_INVALID",
+          message:
+            "Invalid transaction: \n" +
+            "  A value is required",
+        }
       });
     }
   });
@@ -99,6 +117,7 @@ describe("Errors", () => {
     }
     catch (error) {
       validateShipEngineError(error, {
+        name: "Error",
         code: "ERR_INVALID_INPUT",
         message:
           "Invalid input to the createShipment method. \n" +
@@ -114,7 +133,14 @@ describe("Errors", () => {
               key: "id",
             },
           }
-        ]
+        ],
+        originalError: {
+          name: "Error",
+          code: "ERR_INVALID",
+          message:
+            "Invalid transaction: \n" +
+            "  id is required",
+        }
       });
     }
   });
@@ -130,12 +156,20 @@ describe("Errors", () => {
     }
     catch (error) {
       validateShipEngineError(error, {
-        code: "ERR_INVALID",
+        name: "Error",
+        code: "ERR_APP_ERROR",
         transactionID: error.transactionID,
         message:
           "Error in the createShipment method. \n" +
           "Invalid shipment: \n" +
           "  A value is required",
+        originalError: {
+          name: "Error",
+          code: "ERR_INVALID",
+          message:
+            "Invalid shipment: \n" +
+            "  A value is required",
+        }
       });
     }
   });
@@ -153,7 +187,8 @@ describe("Errors", () => {
     }
     catch (error) {
       validateShipEngineError(error, {
-        code: "ERR_INVALID",
+        name: "Error",
+        code: "ERR_APP_ERROR",
         transactionID: error.transactionID,
         message:
           "Error in the createShipment method. \n" +
@@ -189,7 +224,16 @@ describe("Errors", () => {
               key: "packages",
             },
           }
-        ]
+        ],
+        originalError: {
+          name: "Error",
+          code: "ERR_INVALID",
+          message:
+            "Invalid shipment: \n" +
+            "  label is required \n" +
+            "  charges is required \n" +
+            "  packages is required",
+        }
       });
     }
   });
@@ -211,239 +255,148 @@ describe("Errors", () => {
     }
     catch (error) {
       validateShipEngineError(error, {
+        name: "Error",
         code: "ERR_INVALID_INPUT",
         message:
           "Invalid input to the createShipment method. \n" +
           "All packages in a shipment must be insured in the same currency. \n" +
           "Currency mismatch: USD, EUR, GBP. All monetary values must be in the same currency.",
         currencies: ["USD", "EUR", "GBP"],
+        originalError: {
+          name: "Error",
+          code: "ERR_CURRENCY_MISMATCH",
+          message:
+            "Currency mismatch: USD, EUR, GBP. All monetary values must be in the same currency.",
+        }
       });
     }
   });
-});
 
-describe("BadRequestError", () => {
-  it("can be initialized with a message string", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.BadRequestError(message);
+  const errorClasses = [
+    { ErrorClass: AppError, code: "ERR_APP_ERROR" },
+    { ErrorClass: ValidationError, code: "ERR_INVALID" },
+    { ErrorClass: UnauthorizedError, code: "ERR_UNAUTHORIZED" },
+    { ErrorClass: ExternalError, code: "ERR_EXTERNAL" },
+  ];
 
-    expect(subject.message).to.equal(message);
-  });
+  for (const { ErrorClass, code } of errorClasses) {
+    describe(ErrorClass.name, () => {
+      it("can be initialized with a message string", () => {
+        const error = new ErrorClass("test");
+        validateShipEngineError(error, {
+          name: ErrorClass.name,
+          message: "test",
+          code,
+        });
+      });
 
-  it("can be initialized with an object", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.BadRequestError({ message });
+      it("can be initialized with an object", () => {
+        const error = new ErrorClass({ message: "test" });
+        validateShipEngineError(error, {
+          name: ErrorClass.name,
+          message: "test",
+          code,
+        });
+      });
 
-    expect(subject.message).to.equal(message);
-  });
+      it("can be initialized with props", () => {
+        const error = new ErrorClass({
+          message: "test",
+          statusCode: 509,
+          originalError: new SyntaxError("bad syntax"),
+          customProperty: "foo",
+        });
 
-  it("sets default attributes", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.BadRequestError(message);
+        validateShipEngineError(error, {
+          name: ErrorClass.name,
+          message: "test",
+          code,
+          statusCode: 509,
+          customProperty: "foo",
+          originalError: {
+            name: "SyntaxError",
+            message: "bad syntax"
+          }
+        });
+      });
 
-    expect(subject.code).to.equal("ERR_BAD_REQUEST");
-    expect(subject.source).to.equal("external");
-    expect(subject.statusCode).to.equal(400);
-    expect(subject.canBeRetried).to.equal(false);
-    expect(subject.fieldErrors).to.be.equal(undefined);
+      it("should copy props from the original error", () => {
+        const error = new ErrorClass({
+          message: "test",
+          originalError: Object.assign(new SyntaxError("bad syntax"), {
+            customProperty: "foo"
+          }),
+        });
 
-  });
+        validateShipEngineError(error, {
+          name: ErrorClass.name,
+          message: "test",
+          code,
+          customProperty: "foo",
+          originalError: {
+            name: "SyntaxError",
+            message: "bad syntax",
+            customProperty: "foo",
+          }
+        });
+      });
 
-  it("can set the transactionID", () => {
-    const transactionID = "test";
-    const subject = new ShipEngineErrors.BadRequestError({ transactionID });
+      it("should NOT override the code from props or original error", () => {
+        const error = new ErrorClass({
+          message: "test",
+          code: "SOME_CODE",
+          originalError: Object.assign(new SyntaxError("bad syntax"), {
+            code: "SOME OTHER CODE"
+          }),
+        });
 
-    expect(subject.transactionID).to.equal(transactionID);
-  });
+        validateShipEngineError(error, {
+          name: ErrorClass.name,
+          message: "test",
+          code,
+          originalError: {
+            name: "SyntaxError",
+            message: "bad syntax",
+            code: "SOME OTHER CODE",
+          }
+        });
+      });
+    });
+  }
 
-  it("can set the originalError", () => {
-    const originalError = new Error("test");
-    const subject = new ShipEngineErrors.BadRequestError({ originalError });
+  describe("ExternalError-specific functionality", () => {
+    it("should have externalErrors and externalWarnings, even if none were specified", () => {
+      const error = new ExternalError({
+        message: "test",
+        statusCode: 509,
+      });
 
-    expect(subject.originalError).to.eql(originalError);
-  });
-});
+      validateShipEngineError(error, {
+        name: "ExternalError",
+        message: "test",
+        code: "ERR_EXTERNAL",
+        statusCode: 509,
+        externalErrors: [],
+        externalWarnings: [],
+      });
+    });
 
-describe("UnauthorizedError", () => {
-  it("can be initialized with a message string", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.UnauthorizedError(message);
+    it("can be initialized with external errors/warnings", () => {
+      const error = new ExternalError({
+        message: "test",
+        statusCode: 509,
+        externalErrors: ["one", "two", "three"],
+        externalWarnings: ["four", "five", "six"],
+      });
 
-    expect(subject.message).to.equal(message);
-  });
-
-  it("can be initialized with an object", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.UnauthorizedError({ message });
-
-    expect(subject.message).to.equal(message);
-  });
-
-  it("sets default attributes", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.UnauthorizedError(message);
-
-    expect(subject.code).to.equal("ERR_UNAUTHORIZED");
-    expect(subject.source).to.equal("external");
-    expect(subject.statusCode).to.equal(401);
-    expect(subject.canBeRetried).to.equal(false);
-  });
-
-  it("can set the transactionID", () => {
-    const transactionID = "test";
-    const subject = new ShipEngineErrors.UnauthorizedError({ transactionID });
-
-    expect(subject.transactionID).to.equal(transactionID);
-  });
-
-  it("can set the originalError", () => {
-    const originalError = new Error("test");
-    const subject = new ShipEngineErrors.UnauthorizedError({ originalError });
-
-    expect(subject.originalError).to.eql(originalError);
-  });
-});
-
-describe("NotFoundError", () => {
-  it("can be initialized with a message string", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.NotFoundError(message);
-
-    expect(subject.message).to.equal(message);
-  });
-
-  it("can be initialized with an object", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.NotFoundError({ message });
-
-    expect(subject.message).to.equal(message);
-  });
-
-  it("sets default attributes", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.NotFoundError(message);
-
-    expect(subject.code).to.equal("ERR_NOT_FOUND");
-    expect(subject.source).to.equal("external");
-    expect(subject.statusCode).to.equal(404);
-    expect(subject.canBeRetried).to.equal(false);
-  });
-
-  it("can set the transactionID", () => {
-    const transactionID = "test";
-    const subject = new ShipEngineErrors.NotFoundError({ transactionID });
-
-    expect(subject.transactionID).to.equal(transactionID);
-  });
-
-  it("can set the originalError", () => {
-    const originalError = new Error("test");
-    const subject = new ShipEngineErrors.NotFoundError({ originalError });
-
-    expect(subject.originalError).to.eql(originalError);
-  });
-});
-
-describe("RateLimitError", () => {
-  it("can be initialized with a message string", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.NotFoundError(message);
-
-    expect(subject.message).to.equal(message);
-  });
-
-  it("can be initialized with an object", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.RateLimitError({ message });
-
-    expect(subject.message).to.equal(message);
-  });
-
-  it("sets default attributes", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.RateLimitError(message);
-
-    expect(subject.code).to.equal("ERR_RATE_LIMIT");
-    expect(subject.source).to.equal("external");
-    expect(subject.statusCode).to.equal(429);
-    expect(subject.canBeRetried).to.equal(true);
-    expect(subject.retryInMilliseconds).to.equal(undefined);
-  });
-
-  it("can set the transactionID", () => {
-    const transactionID = "test";
-    const subject = new ShipEngineErrors.RateLimitError({ transactionID });
-
-    expect(subject.transactionID).to.equal(transactionID);
-  });
-
-  it("can set the originalError", () => {
-    const originalError = new Error("test");
-    const subject = new ShipEngineErrors.RateLimitError({ originalError });
-
-    expect(subject.originalError).to.eql(originalError);
-  });
-
-  it("can set the retryInMilliseconds", () => {
-    const retryInMilliseconds = 2000;
-    const subject = new ShipEngineErrors.RateLimitError({ retryInMilliseconds });
-
-    expect(subject.retryInMilliseconds).to.equal(retryInMilliseconds);
-  });
-});
-
-describe("ExternalServiceError", () => {
-  it("can be initialized with a message string", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.ExternalServiceError(message);
-
-    expect(subject.message).to.equal(message);
-  });
-
-  it("can be initialized with an object", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.ExternalServiceError({ message });
-
-    expect(subject.message).to.equal(message);
-  });
-
-  it("sets default attributes", () => {
-    const message = "test";
-    const subject = new ShipEngineErrors.ExternalServiceError(message);
-
-    expect(subject.code).to.equal("ERR_EXTERNAL_SERVICE_ERROR");
-    expect(subject.source).to.equal("external");
-    expect(subject.statusCode).to.equal(520);
-    expect(subject.canBeRetried).to.equal(true);
-    expect(subject.externalErrors).to.equal(undefined);
-    expect(subject.externalWarnings).to.equal(undefined);
-  });
-
-  it("can set the transactionID", () => {
-    const transactionID = "test";
-    const subject = new ShipEngineErrors.ExternalServiceError({ transactionID });
-
-    expect(subject.transactionID).to.equal(transactionID);
-  });
-
-  it("can set the originalError", () => {
-    const originalError = new Error("test");
-    const subject = new ShipEngineErrors.ExternalServiceError({ originalError });
-
-    expect(subject.originalError).to.eql(originalError);
-  });
-
-  it("can set the externalErrors", () => {
-    const externalErrors = ["test"];
-    const subject = new ShipEngineErrors.ExternalServiceError({ externalErrors });
-
-    expect(subject.externalErrors).to.eql(externalErrors);
-  });
-
-  it("can set the externalWarnings", () => {
-    const externalWarnings = ["test"];
-    const subject = new ShipEngineErrors.ExternalServiceError({ externalWarnings });
-
-    expect(subject.externalWarnings).to.eql(externalWarnings);
+      validateShipEngineError(error, {
+        name: "ExternalError",
+        message: "test",
+        code: "ERR_EXTERNAL",
+        statusCode: 509,
+        externalErrors: ["one", "two", "three"],
+        externalWarnings: ["four", "five", "six"],
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR normalizes and simplifies the error functionality in the SDK.

* Error codes that are only meant for internal use were moved to the "internal" section of the SDK

* Error codes and classes that were HTTP-specific (e.g. `BadRequestError`, `NotFoundError`, etc.) have been removed and replaced with a single `ExternalError` class and `ERR_EXTERNAL` code

* Errors that occur in app methods are now _always_ wrapped. 
  * If the error is due to invalid input data from the back-end IPaaS platform, then it will be wrapped in an `ERR_INVALID_INPUT` error.
  * If the error is due to a bug in the app code, then it will be wrapped in an `ERR_APP_ERROR` error
  * Either way, the original error (including the original error code) can be obtained via the `originalError` property