### PR TITLE
revert some of the validation changes

### DIFF
--- a/src/internal/common/addresses/address-with-contact-info.ts
+++ b/src/internal/common/addresses/address-with-contact-info.ts
@@ -10,16 +10,14 @@ export class AddressWithContactInfo extends AddressBase implements IAddressWithC
     schema: Address[_internal].schema.concat(ContactInfo[_internal].schema),
   };
 
-  public readonly name?: PersonName;
-  public readonly email?: string;
-  public readonly phoneNumber?: string;
+  public readonly name: PersonName;
+  public readonly email: string;
+  public readonly phoneNumber: string;
 
   public constructor(pojo: AddressWithContactInfoPOJO) {
     super(pojo);
 
-    if (pojo.name) {
-      this.name = new PersonName(pojo.name);
-    }
+    this.name = new PersonName(pojo.name);
     this.email = pojo.email || "";
     this.phoneNumber = pojo.phoneNumber || "";
 

--- a/src/internal/common/addresses/address.ts
+++ b/src/internal/common/addresses/address.ts
@@ -9,8 +9,8 @@ export abstract class AddressBase extends PartialAddressBase implements IAddress
   public toString(): string {
     const address = [];
     this.company && address.push(this.company);
-    this.addressLines && address.push(...this.addressLines);
-    this.cityLocality && this.stateProvince && address.push(`${this.cityLocality}, ${this.stateProvince} ${this.postalCode}`);
+    address.push(...this.addressLines);
+    address.push(`${this.cityLocality}, ${this.stateProvince} ${this.postalCode}`);
     address.push(this.country);
     return address.join("\n");
   }
@@ -21,9 +21,9 @@ export class Address extends AddressBase {
   public static readonly [_internal] = {
     label: "address",
     schema: PartialAddress[_internal].schema.keys({
-      addressLines: Joi.array().items(Joi.string().max(100).allow("").optional()).optional(),
-      cityLocality: Joi.string().max(100).allow("").optional(),
-      stateProvince: Joi.string().max(100).allow("").optional(),
+      addressLines: Joi.array().items(Joi.string().max(100).allow("")).required(),
+      cityLocality: Joi.string().max(100).allow("").required(),
+      stateProvince: Joi.string().max(100).allow("").required(),
       postalCode: Joi.string().max(100).required(),
       country: Joi.string().enum(Country).required()
     }),

--- a/src/internal/common/addresses/contact-info.ts
+++ b/src/internal/common/addresses/contact-info.ts
@@ -4,15 +4,12 @@ import { Joi } from "../validation";
 import { PersonName } from "./person-name";
 
 export class ContactInfoBase implements IContactInfo {
-  public readonly name?: PersonName;
-  public readonly email?: string;
-  public readonly phoneNumber?: string;
+  public readonly name: PersonName;
+  public readonly email: string;
+  public readonly phoneNumber: string;
 
   public constructor(pojo: ContactInfoPOJO) {
-    if (pojo.name) {
-      this.name = new PersonName(pojo.name);
-    }
-
+    this.name = new PersonName(pojo.name);
     this.email = pojo.email || "";
     this.phoneNumber = pojo.phoneNumber || "";
   }
@@ -22,9 +19,9 @@ export class ContactInfo extends ContactInfoBase {
   public static readonly [_internal] = {
     label: "contact info",
     schema: Joi.object({
-      name: PersonName[_internal].schema.optional(),
-      email: Joi.string().email().allow("").optional(),
-      phoneNumber: Joi.string().allow("").max(30).optional()
+      name: PersonName[_internal].schema.required(),
+      email: Joi.string().email().allow(""),
+      phoneNumber: Joi.string().trim().singleLine().allow("").max(30)
     }),
   };
 

--- a/src/internal/common/addresses/partial-address.ts
+++ b/src/internal/common/addresses/partial-address.ts
@@ -5,20 +5,20 @@ import { Joi } from "../validation";
 export type PartialAddressPOJO = Partial<AddressPOJO>;
 
 export interface PartialAddress {
-  readonly company?: string;
-  readonly addressLines?: readonly string[];
-  readonly cityLocality?: string;
-  readonly stateProvince?: string;
+  readonly company: string;
+  readonly addressLines: readonly string[];
+  readonly cityLocality: string;
+  readonly stateProvince: string;
   readonly postalCode: string;
   readonly country?: Country;
   readonly isResidential?: boolean;
 }
 
 export abstract class PartialAddressBase {
-  public readonly company?: string;
-  public readonly addressLines?: readonly string[];
-  public readonly cityLocality?: string;
-  public readonly stateProvince?: string;
+  public readonly company: string;
+  public readonly addressLines: readonly string[];
+  public readonly cityLocality: string;
+  public readonly stateProvince: string;
   public readonly postalCode: string;
   public readonly country?: Country;
   public readonly isResidential?: boolean;
@@ -39,11 +39,11 @@ export class PartialAddress extends PartialAddressBase {
   public static readonly [_internal] = {
     label: "address",
     schema: Joi.object({
-      company: Joi.string().allow("").max(100).optional(),
-      addressLines: Joi.array().items(Joi.string().max(100).allow("").optional()).optional(),
-      cityLocality: Joi.string().max(100).allow("").optional(),
-      stateProvince: Joi.string().max(100).allow("").optional(),
-      postalCode: Joi.string().max(100),
+      company: Joi.string().trim().singleLine().allow("").max(100),
+      addressLines: Joi.array().items(Joi.string().trim().singleLine().max(100).allow("")),
+      cityLocality: Joi.string().trim().singleLine().max(100).allow(""),
+      stateProvince: Joi.string().trim().singleLine().max(100).allow(""),
+      postalCode: Joi.string().trim().singleLine().max(100),
       country: Joi.string().enum(Country),
       isResidential: Joi.boolean()
     }),

--- a/src/internal/common/addresses/person-name.ts
+++ b/src/internal/common/addresses/person-name.ts
@@ -6,7 +6,7 @@ export class PersonName implements IPersonName {
   public static readonly [_internal] = {
     label: "name",
     schema: Joi.alternatives(
-      Joi.string().allow("").max(100).optional(),
+      Joi.string().allow("").max(100),
       Joi.object({
         title: Joi.string().trim().singleLine().allow("").max(100),
         given: Joi.string().trim().singleLine().min(1).max(100).required(),

--- a/src/public/common/addresses/address.ts
+++ b/src/public/common/addresses/address.ts
@@ -5,9 +5,9 @@ import type { Country } from "../country";
  */
 export interface AddressPOJO {
   company?: string;
-  addressLines?: readonly string[];
-  cityLocality?: string;
-  stateProvince?: string;
+  addressLines: readonly string[];
+  cityLocality: string;
+  stateProvince: string;
   postalCode: string;
   country: Country;
   isResidential?: boolean;
@@ -18,10 +18,10 @@ export interface AddressPOJO {
  * A mailing address
  */
 export interface Address {
-  readonly company?: string;
-  readonly addressLines?: readonly string[];
-  readonly cityLocality?: string;
-  readonly stateProvince?: string;
+  readonly company: string;
+  readonly addressLines: readonly string[];
+  readonly cityLocality: string;
+  readonly stateProvince: string;
   readonly postalCode: string;
   readonly country: Country;
   readonly isResidential?: boolean;

--- a/src/public/common/addresses/contact-info.ts
+++ b/src/public/common/addresses/contact-info.ts
@@ -4,7 +4,7 @@ import type { PersonName, PersonNamePOJO } from "./person-name";
  * A person's contact information
  */
 export interface ContactInfoPOJO {
-  name?: string | PersonNamePOJO;
+  name: string | PersonNamePOJO;
   email?: string;
   phoneNumber?: string;
 }
@@ -13,7 +13,7 @@ export interface ContactInfoPOJO {
  * A person's contact information
  */
 export interface ContactInfo {
-  readonly name?: PersonName;
-  readonly email?: string;
-  readonly phoneNumber?: string;
+  readonly name: PersonName;
+  readonly email: string;
+  readonly phoneNumber: string;
 }


### PR DESCRIPTION
update the constructor to allow for looser validation but to also ensure consistency with how the rest of the SDK initializes missing properties. Largely based off of this diff from changes from the previous week.

https://github.com/ShipEngine/connect-sdk/compare/859414b66ad6cbfe5330d2ce20b589b9a2fef1c1...6fc43de79b73437ec8be7c4e20740d46607efb7c