### PR TITLE
Dx 436 weight dimensions validation

### DIFF
--- a/src/internal/common/measures/dimensions.ts
+++ b/src/internal/common/measures/dimensions.ts
@@ -1,4 +1,5 @@
 import { Dimensions as IDimensions, DimensionsPOJO, LengthUnit } from "../../../public";
+import { error, SystemErrorCode } from "../errors";
 import { hideAndFreeze, _internal } from "../utils";
 import { Joi } from "../validation";
 
@@ -19,10 +20,24 @@ export class Dimensions implements IDimensions {
   public readonly unit: LengthUnit;
 
   public constructor(pojo: DimensionsPOJO) {
+
     this.length = pojo.length;
     this.width = pojo.width;
     this.height = pojo.height;
     this.unit = pojo.unit;
+
+    // Check that at least two of the three dimensions properties are set. (Allows for 2 dimensional packages such as envelopes)
+    const zeroCount = [this.length, this.width, this.height].reduce((totalCount, currentValue) => {
+      if(!currentValue) {
+        return totalCount + 1;
+      }
+      return totalCount;
+    }, 0);
+
+    if (zeroCount > 1) {
+      const message = "Dimensions property must have at least 2 of the 3 length, width, and height properties set.";
+      throw error(SystemErrorCode.InvalidInput, message);
+    }
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/internal/common/measures/weight.ts
+++ b/src/internal/common/measures/weight.ts
@@ -6,7 +6,7 @@ export class Weight implements IWeight {
   public static readonly [_internal] = {
     label: "weight",
     schema: Joi.object({
-      value: Joi.number().min(0).required(),
+      value: Joi.number().greater(0).required(),
       unit: Joi.string().enum(WeightUnit).required(),
     }),
   };

--- a/test/specs/carriers/create-shipment.spec.js
+++ b/test/specs/carriers/create-shipment.spec.js
@@ -491,5 +491,36 @@ describe("createShipment", () => {
         expect(error.message).to.equal("Error in the createShipment method. Label data cannot be empty");
       }
     });
+
+    it("should throw an error if the package weight is set to 0", async () => {
+      let app = new CarrierApp(pojo.carrierApp({
+        createShipment: () => ({
+          charges: [{
+            type: "shipping",
+            amount: {
+              value: 123.456,
+              currency: "CAD",
+            },
+          }],
+          label: {
+            type: "label",
+            size: "letter",
+            format: "pdf",
+            data: Buffer.from("data"),
+          }
+        })
+      }));
+
+      const newShipment = pojo.newShipment();
+      newShipment.packages[0].weight = { value: 0, unit: "lb"};
+      
+      try {
+        await app.createShipment(pojo.transaction(), newShipment);
+        assert.fail("An error should have been thrown");
+      }
+      catch (error) {
+        expect(error.message).to.equal("Invalid input to the createShipment method. Invalid shipment: packages[0].weight.value must be greater than 0");
+      }
+    });
   });
 });

--- a/test/specs/carriers/create-shipment.spec.js
+++ b/test/specs/carriers/create-shipment.spec.js
@@ -4,7 +4,7 @@ const { CarrierApp } = require("../../../lib/internal");
 const pojo = require("../../utils/pojo");
 const { expect, assert } = require("chai");
 
-describe("createShipment", () => {
+describe.only("createShipment", () => {
 
   it("should return a shipment from minimal return values", async () => {
     let app = new CarrierApp(pojo.carrierApp({
@@ -366,6 +366,134 @@ describe("createShipment", () => {
     });
   });
 
+  it("should accept all values for the dimensions property", async () => {
+    let app = new CarrierApp(pojo.carrierApp({
+      createShipment: () => ({
+        charges: [{
+          type: "shipping",
+          amount: {
+            value: 123.456,
+            currency: "CAD",
+          },
+        }],
+        label: {
+          type: "label",
+          size: "letter",
+          format: "pdf",
+          data: Buffer.from("data"),
+        },
+        packages: [{}]
+      })
+    }));
+
+
+    const newShipment = pojo.newShipment();
+    newShipment.packages[0].dimensions = {
+      length: 1,
+      width: 1,
+      height: 1,
+      unit: "in"
+    };
+
+    let confirmation = await app.createShipment(pojo.transaction(), newShipment);
+
+    expect(confirmation).to.deep.equal({
+      trackingNumber: "",
+      identifiers: {},
+      deliveryDateTime: undefined,
+      charges: [{
+        name: "",
+        type: "shipping",
+        amount: {
+          value: 123.46,
+          currency: "CAD",
+        }
+      }],
+      totalAmount: {
+        value: 123.46,
+        currency: "CAD",
+      },
+      label: {
+        name: "Label",
+        type: "label",
+        size: "letter",
+        format: "pdf",
+        data: Buffer.from("data"),
+        referenceFields: [],
+      },
+      form: undefined,
+      packages: [{
+        trackingNumber: "",
+        identifiers: {},
+        metadata: {}
+      }],
+    });
+  });
+
+  it("should accept two values for the dimensions property", async () => {
+    let app = new CarrierApp(pojo.carrierApp({
+      createShipment: () => ({
+        charges: [{
+          type: "shipping",
+          amount: {
+            value: 123.456,
+            currency: "CAD",
+          },
+        }],
+        label: {
+          type: "label",
+          size: "letter",
+          format: "pdf",
+          data: Buffer.from("data"),
+        },
+        packages: [{}]
+      })
+    }));
+
+
+    const newShipment = pojo.newShipment();
+    newShipment.packages[0].dimensions = {
+      length: 1,
+      width: 1,
+      height: 0,
+      unit: "in"
+    };
+
+    let confirmation = await app.createShipment(pojo.transaction(), newShipment);
+
+    expect(confirmation).to.deep.equal({
+      trackingNumber: "",
+      identifiers: {},
+      deliveryDateTime: undefined,
+      charges: [{
+        name: "",
+        type: "shipping",
+        amount: {
+          value: 123.46,
+          currency: "CAD",
+        }
+      }],
+      totalAmount: {
+        value: 123.46,
+        currency: "CAD",
+      },
+      label: {
+        name: "Label",
+        type: "label",
+        size: "letter",
+        format: "pdf",
+        data: Buffer.from("data"),
+        referenceFields: [],
+      },
+      form: undefined,
+      packages: [{
+        trackingNumber: "",
+        identifiers: {},
+        metadata: {}
+      }],
+    });
+  });
+
   describe("Failure tests", () => {
     it("should throw an error if called with no arguments", async () => {
       let app = new CarrierApp(pojo.carrierApp({
@@ -520,6 +648,37 @@ describe("createShipment", () => {
       }
       catch (error) {
         expect(error.message).to.equal("Invalid input to the createShipment method. Invalid shipment: packages[0].weight.value must be greater than 0");
+      }
+    });
+
+    it("should throw an error if the dimensions property doesn't have at least two properties set to greater than 0", async () => {
+      let app = new CarrierApp(pojo.carrierApp({
+        createShipment: () => ({
+          charges: [{
+            type: "shipping",
+            amount: {
+              value: 123.456,
+              currency: "CAD",
+            },
+          }],
+          label: {
+            type: "label",
+            size: "letter",
+            format: "pdf",
+            data: Buffer.from("data"),
+          }
+        })
+      }));
+
+      const newShipment = pojo.newShipment();
+      newShipment.packages[0].dimensions = { length: 0, width: 0, height: 1, unit: "in"};
+      
+      try {
+        await app.createShipment(pojo.transaction(), newShipment);
+        assert.fail("An error should have been thrown");
+      }
+      catch (error) {
+        expect(error.message).to.equal("Invalid input to the createShipment method. Dimensions property must have at least 2 of the 3 length, width, and height properties set.");
       }
     });
   });

--- a/test/specs/carriers/create-shipment.spec.js
+++ b/test/specs/carriers/create-shipment.spec.js
@@ -4,7 +4,7 @@ const { CarrierApp } = require("../../../lib/internal");
 const pojo = require("../../utils/pojo");
 const { expect, assert } = require("chai");
 
-describe.only("createShipment", () => {
+describe("createShipment", () => {
 
   it("should return a shipment from minimal return values", async () => {
     let app = new CarrierApp(pojo.carrierApp({


### PR DESCRIPTION
https://auctane.atlassian.net/browse/DX-436

It's a relatively simple update to the dimensions and weight validations.
* `weight` cannot be initialized and be zero.
* `dimensions` must have at least two of the three `length`, `width`, `height` properties set. This allows for rating 2 dimensional packages such as envelopes.