### PR TITLE
PLAT-1166 Add Provider Id to the Spec

### DIFF
--- a/src/internal/common/app.ts
+++ b/src/internal/common/app.ts
@@ -14,8 +14,8 @@ export abstract class App {
   public static readonly [_internal] = {
     label: "ShipEngine Connect app",
     schema: Joi.object({
-      providerId: Joi.string().uuid().optional(),
       id: Joi.string().uuid().required(),
+      providerId: Joi.string().uuid().optional(),
       manifest: Joi.object({
         name: Joi.string().appName().required(),
         version: Joi.string().semver().required(),
@@ -32,11 +32,14 @@ export abstract class App {
 
   public abstract readonly type: AppType;
   public readonly id: UUID;
+  public readonly providerId: UUID;
   public readonly manifest: AppManifest;
   public readonly sdkVersion: number;
 
   public constructor(pojo: AppPOJO) {
+
     this.id = pojo.id;
+    this.providerId = pojo.providerId || "";
     this.sdkVersion = Number.parseFloat(sdk.version);
     this.manifest = {
       ...pojo.manifest,

--- a/src/internal/common/app.ts
+++ b/src/internal/common/app.ts
@@ -14,6 +14,7 @@ export abstract class App {
   public static readonly [_internal] = {
     label: "ShipEngine Connect app",
     schema: Joi.object({
+      providerId: Joi.string().uuid().optional(),
       id: Joi.string().uuid().required(),
       manifest: Joi.object({
         name: Joi.string().appName().required(),

--- a/src/public/common/app.ts
+++ b/src/public/common/app.ts
@@ -6,10 +6,16 @@ import type { UUID } from "./types";
  */
 export interface AppDefinition {
   /**
-   * A UUID that uniquely identifies the carrier.
+   * A UUID that uniquely identifies the app.
    * This ID should never change.
    */
   id: UUID;
+
+  /**
+   * An optional UUID that is used to relate this app to an existing production app.
+   * Do not set this field unless instructed to by the shipengine connect team.
+   */
+  providerId?: UUID;
 }
 
 

--- a/test/specs/carriers/carrier-app.spec.js
+++ b/test/specs/carriers/carrier-app.spec.js
@@ -26,6 +26,7 @@ describe("CarrierApp", () => {
     expect(app).to.deep.equal({
       type: "carrier",
       id: "12345678-1234-1234-1234-123456789012",
+      providerId: "",
       name: "My carrier",
       description: "",
       websiteURL: new URL("https://my-carrier.com/"),
@@ -63,6 +64,7 @@ describe("CarrierApp", () => {
   it("should create a CarrierApp with all possible fields", () => {
     let app = new CarrierApp({
       id: "12345678-1234-1234-1234-123456789012",
+      providerId: "12345678-1234-1234-1234-123456789012",
       name: "My carrier",
       description: "My carrier description",
       websiteURL: "https://my-carrier.com/",
@@ -102,6 +104,7 @@ describe("CarrierApp", () => {
     expect(app).to.deep.equal({
       type: "carrier",
       id: "12345678-1234-1234-1234-123456789012",
+      providerId: "12345678-1234-1234-1234-123456789012",
       name: "My carrier",
       description: "My carrier description",
       websiteURL: new URL("https://my-carrier.com/"),
@@ -154,6 +157,7 @@ describe("CarrierApp", () => {
     expect(app).to.deep.equal({
       type: "carrier",
       id: "12345678-1234-1234-1234-123456789012",
+      providerId: "",
       name: "My carrier",
       description: "",
       websiteURL: new URL("https://my-carrier.com/"),

--- a/test/specs/orders/order-app.spec.js
+++ b/test/specs/orders/order-app.spec.js
@@ -24,6 +24,7 @@ describe("OrderApp", () => {
     expect(app).to.deep.equal({
       type: "order",
       id: "12345678-1234-1234-1234-123456789012",
+      providerId: "",
       name: "My order",
       description: "",
       websiteURL: new URL("https://my-order.com/"),
@@ -52,6 +53,7 @@ describe("OrderApp", () => {
   it("should create an OrderApp with all possible fields", () => {
     let app = new OrderApp({
       id: "12345678-1234-1234-1234-123456789012",
+      providerId: "12345678-1234-1234-1234-123456789012",
       name: "My order",
       description: "My order description",
       websiteURL: "https://my-order.com/",
@@ -83,6 +85,7 @@ describe("OrderApp", () => {
     expect(app).to.deep.equal({
       type: "order",
       id: "12345678-1234-1234-1234-123456789012",
+      providerId: "12345678-1234-1234-1234-123456789012",
       name: "My order",
       description: "My order description",
       websiteURL: new URL("https://my-order.com/"),
@@ -130,6 +133,7 @@ describe("OrderApp", () => {
     expect(app).to.deep.equal({
       type: "order",
       id: "12345678-1234-1234-1234-123456789012",
+      providerId: "",
       name: "My order",
       description: "",
       websiteURL: new URL("https://my-order.com/"),


### PR DESCRIPTION
When we export existing modules into shipengine/connect from the registry, we need to be able to specify the providerId which will then become the app id in the web api.

https://auctane.atlassian.net/browse/PLAT-1166