### PR TITLE
OAuth encoding is optional

### DIFF
--- a/src/internal/common/oauth/parameter.ts
+++ b/src/internal/common/oauth/parameter.ts
@@ -14,7 +14,7 @@ export class OAuthParameter {
 
   public readonly name: string;
   public readonly value: string;
-  public readonly encoding: string;
+  public readonly encoding?: string;
 
   public constructor(pojo: OAuthParameterDefinition) {
     this.name = pojo.name;

--- a/src/public/common/oauth/parameter.ts
+++ b/src/public/common/oauth/parameter.ts
@@ -4,5 +4,5 @@
 export interface OAuthParameterDefinition {
   name: string;
   value: string;
-  encoding: string;
+  encoding?: string;
 }


### PR DESCRIPTION
This was accidentally broken in #41 