### PR TITLE
Add enum type to payment method on Sales Order

### DIFF
--- a/src/internal/orders/sales-order.ts
+++ b/src/internal/orders/sales-order.ts
@@ -14,7 +14,7 @@ export class SalesOrder extends SalesOrderIdentifierBase {
       createdDateTime: DateTimeZone[_internal].schema.required(),
       lastModifiedDateTime: DateTimeZone[_internal].schema.optional(),
       status: Joi.string().enum(SalesOrderStatus).required(),
-      paymentMethod: Joi.alternatives(Joi.string(), Joi.string().enum(PaymentMethod)),
+      paymentMethod: Joi.alternatives(Joi.string().enum(PaymentMethod), Joi.string()),
       paymentStatus: Joi.string().enum(PaymentStatus),
       orderURL: Joi.alternatives(Joi.object().website(), Joi.string().website()),
       buyer: Buyer[_internal].schema.required(),
@@ -30,7 +30,7 @@ export class SalesOrder extends SalesOrderIdentifierBase {
   public readonly createdDateTime: DateTimeZone;
   public readonly lastModifiedDateTime?: DateTimeZone;
   public readonly status: SalesOrderStatus;
-  public readonly paymentMethod?: string | PaymentMethod ;
+  public readonly paymentMethod?: PaymentMethod | string;
   public readonly paymentStatus: PaymentStatus;
   public readonly orderURL?: URL;
   public readonly buyer: Buyer;

--- a/src/internal/orders/sales-order.ts
+++ b/src/internal/orders/sales-order.ts
@@ -1,4 +1,4 @@
-import { PaymentStatus, SalesOrder as SalesOrderPOJO, SalesOrderStatus } from "../../public";
+import { PaymentMethod, PaymentStatus, SalesOrder as SalesOrderPOJO, SalesOrderStatus } from "../../public";
 import { AddressWithContactInfo, calculateTotalCharges, Charge, DateTimeZone, hideAndFreeze, Joi, MonetaryValue, Note, _internal } from "../common";
 import { Buyer } from "./buyer";
 import { OriginalOrderSource } from "./original-order-source";
@@ -14,7 +14,7 @@ export class SalesOrder extends SalesOrderIdentifierBase {
       createdDateTime: DateTimeZone[_internal].schema.required(),
       lastModifiedDateTime: DateTimeZone[_internal].schema.optional(),
       status: Joi.string().enum(SalesOrderStatus).required(),
-      paymentMethod: Joi.string(),
+      paymentMethod: Joi.alternatives(Joi.string(), Joi.string().enum(PaymentMethod)),
       paymentStatus: Joi.string().enum(PaymentStatus),
       orderURL: Joi.alternatives(Joi.object().website(), Joi.string().website()),
       buyer: Buyer[_internal].schema.required(),
@@ -30,7 +30,7 @@ export class SalesOrder extends SalesOrderIdentifierBase {
   public readonly createdDateTime: DateTimeZone;
   public readonly lastModifiedDateTime?: DateTimeZone;
   public readonly status: SalesOrderStatus;
-  public readonly paymentMethod?: string;
+  public readonly paymentMethod?: string | PaymentMethod ;
   public readonly paymentStatus: PaymentStatus;
   public readonly orderURL?: URL;
   public readonly buyer: Buyer;

--- a/src/public/orders/sales-order.ts
+++ b/src/public/orders/sales-order.ts
@@ -27,7 +27,7 @@ export interface SalesOrder extends SalesOrderIdentifierPOJO {
   /**
    * Indicates how the customer has paid for the order
    */
-  paymentMethod?: string | PaymentMethod;
+  paymentMethod?: PaymentMethod | string;
 
   /**
    * Indicates what the status of the customer payment for this order is.

--- a/src/public/orders/sales-order.ts
+++ b/src/public/orders/sales-order.ts
@@ -1,6 +1,6 @@
 import type { DateTimeZonePOJO, NotePOJO, URLString, Charge } from "../common";
 import type { Buyer } from "./buyer";
-import type { PaymentStatus, SalesOrderStatus } from "./enums";
+import type { PaymentMethod, PaymentStatus, SalesOrderStatus } from "./enums";
 import { OriginalOrderSource } from "./original-order-source";
 import { RequestedFulfillmentPOJO } from "./requested-fulfillment";
 import type { SalesOrderIdentifierPOJO } from "./sales-order-identifier";
@@ -27,7 +27,7 @@ export interface SalesOrder extends SalesOrderIdentifierPOJO {
   /**
    * Indicates how the customer has paid for the order
    */
-  paymentMethod?: string;
+  paymentMethod?: string | PaymentMethod;
 
   /**
    * Indicates what the status of the customer payment for this order is.

--- a/test/utils/pojo.js
+++ b/test/utils/pojo.js
@@ -428,6 +428,7 @@ const pojo = module.exports = {
       createdDateTime: "2005-05-05T05:05:05Z",
       status: "awaiting_shipment",
       buyer: pojo.buyer(),
+      paymentMethod: "cash",
       requestedFulfillments: [
         {
           items: [pojo.salesOrderItem()],


### PR DESCRIPTION
Quick type update for the `SalesOrder.paymentMethod` property to indicate to the app developer that we would _prefer_ it to be one of the enum values but a random string is also valid as well.