### PR TITLE
Dx 651 custom shipping options

### DIFF
--- a/src/internal/carriers/manifests/new-manifest.ts
+++ b/src/internal/carriers/manifests/new-manifest.ts
@@ -1,4 +1,5 @@
 import { AddressPOJO, DateTimeZonePOJO, ErrorCode, ManifestLocation, NewManifest as INewManifest, ShipmentIdentifierPOJO } from "../../../public";
+import { CustomShippingOptions } from "../../../public/carriers/types";
 import { Address, DateTimeZone, error, hideAndFreeze, Joi, _internal } from "../../common";
 import { CarrierApp } from "../carrier-app";
 import { ShipmentIdentifier } from "../shipments/shipment-identifier";
@@ -9,6 +10,7 @@ export interface NewManifestPOJO {
   openDateTime: DateTimeZonePOJO | Date | string;
   closeDateTime: DateTimeZonePOJO | Date | string;
   shipments: readonly ShipmentIdentifierPOJO[];
+  customShippingOptions: Record<string, unknown>;
 }
 
 
@@ -20,6 +22,10 @@ export class NewManifest implements INewManifest {
       openDateTime: DateTimeZone[_internal].schema.required(),
       closeDateTime: DateTimeZone[_internal].schema.required(),
       shipments: Joi.array().items(ShipmentIdentifier[_internal].schema.unknown(true)).required(),
+      customShippingOptions: Joi.object({
+        dangerousGoodsCategory: Joi.string().optional(),
+        billDutiesToSender: Joi.boolean().optional()
+      })
     }),
   };
 
@@ -27,12 +33,14 @@ export class NewManifest implements INewManifest {
   public readonly openDateTime: DateTimeZone;
   public readonly closeDateTime: DateTimeZone;
   public readonly shipments: readonly ShipmentIdentifier[];
+  public readonly customShippingOptions: CustomShippingOptions;
 
   public constructor(pojo: NewManifestPOJO, carrier: CarrierApp) {
     this.shipFrom = pojo.shipFrom && new Address(pojo.shipFrom);
     this.openDateTime = new DateTimeZone(pojo.openDateTime);
     this.closeDateTime = new DateTimeZone(pojo.closeDateTime);
     this.shipments = pojo.shipments.map((shipment) => new ShipmentIdentifier(shipment));
+    this.customShippingOptions = pojo.customShippingOptions || {};
 
     switch (carrier.manifestLocations) {
       case ManifestLocation.AllLocations:

--- a/src/internal/carriers/manifests/new-manifest.ts
+++ b/src/internal/carriers/manifests/new-manifest.ts
@@ -1,5 +1,4 @@
 import { AddressPOJO, DateTimeZonePOJO, ErrorCode, ManifestLocation, NewManifest as INewManifest, ShipmentIdentifierPOJO } from "../../../public";
-import { CustomShippingOptions } from "../../../public/carriers/types";
 import { Address, DateTimeZone, error, hideAndFreeze, Joi, _internal } from "../../common";
 import { CarrierApp } from "../carrier-app";
 import { ShipmentIdentifier } from "../shipments/shipment-identifier";
@@ -10,7 +9,6 @@ export interface NewManifestPOJO {
   openDateTime: DateTimeZonePOJO | Date | string;
   closeDateTime: DateTimeZonePOJO | Date | string;
   shipments: readonly ShipmentIdentifierPOJO[];
-  customShippingOptions: Record<string, unknown>;
 }
 
 
@@ -22,10 +20,6 @@ export class NewManifest implements INewManifest {
       openDateTime: DateTimeZone[_internal].schema.required(),
       closeDateTime: DateTimeZone[_internal].schema.required(),
       shipments: Joi.array().items(ShipmentIdentifier[_internal].schema.unknown(true)).required(),
-      customShippingOptions: Joi.object({
-        dangerousGoodsCategory: Joi.string().optional(),
-        billDutiesToSender: Joi.boolean().optional()
-      })
     }),
   };
 
@@ -33,14 +27,12 @@ export class NewManifest implements INewManifest {
   public readonly openDateTime: DateTimeZone;
   public readonly closeDateTime: DateTimeZone;
   public readonly shipments: readonly ShipmentIdentifier[];
-  public readonly customShippingOptions: CustomShippingOptions;
 
   public constructor(pojo: NewManifestPOJO, carrier: CarrierApp) {
     this.shipFrom = pojo.shipFrom && new Address(pojo.shipFrom);
     this.openDateTime = new DateTimeZone(pojo.openDateTime);
     this.closeDateTime = new DateTimeZone(pojo.closeDateTime);
     this.shipments = pojo.shipments.map((shipment) => new ShipmentIdentifier(shipment));
-    this.customShippingOptions = pojo.customShippingOptions || {};
 
     switch (carrier.manifestLocations) {
       case ManifestLocation.AllLocations:

--- a/src/internal/carriers/pickups/pickup-request.ts
+++ b/src/internal/carriers/pickups/pickup-request.ts
@@ -1,4 +1,5 @@
 import { AddressPOJO, ContactInfoPOJO, NotePOJO, PickupRequest as IPickupRequest, TimeRangePOJO } from "../../../public";
+import { CustomShippingOptions } from "../../../public/carriers/types";
 import { Address, App, ContactInfo, DefinitionIdentifier, hideAndFreeze, Joi, Note, TimeRange, _internal } from "../../common";
 import { PickupService, PickupServiceIdentifierPOJO } from "./pickup-service";
 import { PickupShipment, PickupShipmentPOJO } from "./pickup-shipment";
@@ -10,6 +11,7 @@ export interface PickupRequestPOJO {
   contact: ContactInfoPOJO;
   notes?: readonly NotePOJO[];
   shipments: readonly PickupShipmentPOJO[];
+  customShippingOptions: CustomShippingOptions;
 }
 
 
@@ -26,6 +28,10 @@ export class PickupRequest implements IPickupRequest {
       contact: ContactInfo[_internal].schema.required(),
       notes: Note[_internal].notesSchema,
       shipments: Joi.array().min(1).items(PickupShipment[_internal].schema).required(),
+      customShippingOptions: Joi.object({
+        dangerousGoodsCategory: Joi.string().optional(),
+        billDutiesToSender: Joi.boolean().optional()
+      })
     }),
   };
 
@@ -35,6 +41,7 @@ export class PickupRequest implements IPickupRequest {
   public readonly contact: ContactInfo;
   public readonly notes: readonly Note[];
   public readonly shipments: readonly PickupShipment[];
+  public readonly customShippingOptions: CustomShippingOptions;
 
   public constructor(pojo: PickupRequestPOJO, app: App) {
     this.pickupService = app[_internal].references.lookup(pojo.pickupService, PickupService);
@@ -43,6 +50,7 @@ export class PickupRequest implements IPickupRequest {
     this.contact = new ContactInfo(pojo.contact);
     this.notes = pojo.notes || [];
     this.shipments = pojo.shipments.map((shipment) => new PickupShipment(shipment, app));
+    this.customShippingOptions = pojo.customShippingOptions || {};
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/internal/carriers/pickups/pickup-request.ts
+++ b/src/internal/carriers/pickups/pickup-request.ts
@@ -1,5 +1,4 @@
 import { AddressPOJO, ContactInfoPOJO, NotePOJO, PickupRequest as IPickupRequest, TimeRangePOJO } from "../../../public";
-import { CustomShippingOptions } from "../../../public/carriers/types";
 import { Address, App, ContactInfo, DefinitionIdentifier, hideAndFreeze, Joi, Note, TimeRange, _internal } from "../../common";
 import { PickupService, PickupServiceIdentifierPOJO } from "./pickup-service";
 import { PickupShipment, PickupShipmentPOJO } from "./pickup-shipment";
@@ -11,9 +10,7 @@ export interface PickupRequestPOJO {
   contact: ContactInfoPOJO;
   notes?: readonly NotePOJO[];
   shipments: readonly PickupShipmentPOJO[];
-  customShippingOptions: CustomShippingOptions;
 }
-
 
 export class PickupRequest implements IPickupRequest {
   public static readonly [_internal] = {
@@ -28,10 +25,6 @@ export class PickupRequest implements IPickupRequest {
       contact: ContactInfo[_internal].schema.required(),
       notes: Note[_internal].notesSchema,
       shipments: Joi.array().min(1).items(PickupShipment[_internal].schema).required(),
-      customShippingOptions: Joi.object({
-        dangerousGoodsCategory: Joi.string().optional(),
-        billDutiesToSender: Joi.boolean().optional()
-      })
     }),
   };
 
@@ -41,7 +34,6 @@ export class PickupRequest implements IPickupRequest {
   public readonly contact: ContactInfo;
   public readonly notes: readonly Note[];
   public readonly shipments: readonly PickupShipment[];
-  public readonly customShippingOptions: CustomShippingOptions;
 
   public constructor(pojo: PickupRequestPOJO, app: App) {
     this.pickupService = app[_internal].references.lookup(pojo.pickupService, PickupService);
@@ -50,7 +42,6 @@ export class PickupRequest implements IPickupRequest {
     this.contact = new ContactInfo(pojo.contact);
     this.notes = pojo.notes || [];
     this.shipments = pojo.shipments.map((shipment) => new PickupShipment(shipment, app));
-    this.customShippingOptions = pojo.customShippingOptions || {};
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/internal/carriers/rates/rate-criteria.ts
+++ b/src/internal/carriers/rates/rate-criteria.ts
@@ -4,7 +4,7 @@ import { DeliveryService } from "../delivery-service";
 import { calculateTotalInsuranceAmount } from "../utils";
 import { PackageRateCriteria, PackageRateCriteriaPOJO } from "./package-rate-criteria";
 import { DeliveryConfirmation } from "../delivery-confirmation";
-import { CustomShippingOptions } from "../../../public/carriers/types";
+import { ShippingOptions } from "../../../public/carriers/types";
 
 
 export interface RateCriteriaPOJO {
@@ -17,7 +17,7 @@ export interface RateCriteriaPOJO {
   returns?: { isReturn?: boolean };
   packages: readonly PackageRateCriteriaPOJO[];
   deliveryConfirmation?: DeliveryConfirmationIdentifierPOJO | string;
-  customShippingOptions: CustomShippingOptions;
+  shippingOptions: ShippingOptions;
 }
 
 
@@ -42,7 +42,7 @@ export class RateCriteria implements IRateCriteria {
         DefinitionIdentifier[_internal].schema.unknown(true),
         Joi.string()
       ),
-      customShippingOptions: Joi.object({
+      shippingOptions: Joi.object({
         dangerousGoodsCategory: Joi.string().optional(),
         billDutiesToSender: Joi.boolean().optional()
       })
@@ -58,7 +58,7 @@ export class RateCriteria implements IRateCriteria {
   public readonly totalInsuredValue?: MonetaryValue;
   public readonly packages: readonly PackageRateCriteria[];
   public readonly deliveryConfirmation?: DeliveryConfirmation;
-  public readonly customShippingOptions: CustomShippingOptions;
+  public readonly shippingOptions: ShippingOptions;
 
   public readonly returns: {
     readonly isReturn: boolean;
@@ -91,7 +91,7 @@ export class RateCriteria implements IRateCriteria {
 
     this.deliveryConfirmation = app[_internal].references.lookup(pojo.deliveryConfirmation, DeliveryConfirmation);
 
-    this.customShippingOptions = pojo.customShippingOptions || {};
+    this.shippingOptions = pojo.shippingOptions || {};
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/internal/carriers/rates/rate-criteria.ts
+++ b/src/internal/carriers/rates/rate-criteria.ts
@@ -4,6 +4,7 @@ import { DeliveryService } from "../delivery-service";
 import { calculateTotalInsuranceAmount } from "../utils";
 import { PackageRateCriteria, PackageRateCriteriaPOJO } from "./package-rate-criteria";
 import { DeliveryConfirmation } from "../delivery-confirmation";
+import { CustomShippingOptions } from "../../../public/carriers/types";
 
 
 export interface RateCriteriaPOJO {
@@ -16,6 +17,7 @@ export interface RateCriteriaPOJO {
   returns?: { isReturn?: boolean };
   packages: readonly PackageRateCriteriaPOJO[];
   deliveryConfirmation?: DeliveryConfirmationIdentifierPOJO | string;
+  customShippingOptions: CustomShippingOptions;
 }
 
 
@@ -40,6 +42,10 @@ export class RateCriteria implements IRateCriteria {
         DefinitionIdentifier[_internal].schema.unknown(true),
         Joi.string()
       ),
+      customShippingOptions: Joi.object({
+        dangerousGoodsCategory: Joi.string().optional(),
+        billDutiesToSender: Joi.boolean().optional()
+      })
     }),
   };
 
@@ -52,6 +58,7 @@ export class RateCriteria implements IRateCriteria {
   public readonly totalInsuredValue?: MonetaryValue;
   public readonly packages: readonly PackageRateCriteria[];
   public readonly deliveryConfirmation?: DeliveryConfirmation;
+  public readonly customShippingOptions: CustomShippingOptions;
 
   public readonly returns: {
     readonly isReturn: boolean;
@@ -83,6 +90,8 @@ export class RateCriteria implements IRateCriteria {
     this.totalInsuredValue = calculateTotalInsuranceAmount(this.packages);
 
     this.deliveryConfirmation = app[_internal].references.lookup(pojo.deliveryConfirmation, DeliveryConfirmation);
+
+    this.customShippingOptions = pojo.customShippingOptions || {};
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/internal/carriers/shipments/new-shipment.ts
+++ b/src/internal/carriers/shipments/new-shipment.ts
@@ -4,7 +4,7 @@ import { DeliveryService } from "../delivery-service";
 import { NewPackage, NewPackagePOJO } from "../packages/new-package";
 import { calculateTotalInsuranceAmount } from "../utils";
 import { DeliveryConfirmation } from "../delivery-confirmation";
-import { CustomShippingOptions } from "../../../public/carriers/types";
+import { ShippingOptions } from "../../../public/carriers/types";
 
 export interface NewShipmentPOJO {
   deliveryService: DeliveryServiceIdentifierPOJO | string;
@@ -18,7 +18,7 @@ export interface NewShipmentPOJO {
   };
   packages: readonly NewPackagePOJO[];
   deliveryConfirmation?: DeliveryConfirmationIdentifierPOJO | DeliveryConfirmationType;
-  customShippingOptions?: CustomShippingOptions;
+  shippingOptions?: ShippingOptions;
 }
 
 
@@ -43,9 +43,9 @@ export class NewShipment implements INewShipment {
         Joi.string()
       ),
       packages: Joi.array().min(1).items(NewPackage[_internal].schema).required(),
-      customShippingOptions: Joi.object({
+      shippingOptions: Joi.object({
         dangerousGoodsCategory: Joi.string().optional(),
-        billDutiesToSender: Joi.boolean().optional()
+        billDutiesToSender: Joi.boolean().optional(),
       })
     }),
   };
@@ -57,7 +57,7 @@ export class NewShipment implements INewShipment {
   public readonly shipDateTime: DateTimeZone;
   public readonly totalInsuredValue: MonetaryValue;
   public readonly deliveryConfirmation?: DeliveryConfirmation;
-  public readonly customShippingOptions: CustomShippingOptions;
+  public readonly shippingOptions: ShippingOptions;
 
   public get isNonMachinable(): boolean {
     return this.packages.some((pkg) => pkg.isNonMachinable);
@@ -93,7 +93,7 @@ export class NewShipment implements INewShipment {
     this.packages = pojo.packages.map((parcel) => new NewPackage(parcel, app));
     this.totalInsuredValue = calculateTotalInsuranceAmount(this.packages);
 
-    this.customShippingOptions = pojo.customShippingOptions || {};
+    this.shippingOptions = pojo.shippingOptions || {};
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/public/carriers/index.ts
+++ b/src/public/carriers/index.ts
@@ -38,3 +38,4 @@ export * from "./tracking/package-tracking-info";
 export * from "./tracking/tracking-criteria";
 export * from "./tracking/tracking-event";
 export * from "./tracking/tracking-info";
+export * from "./types";

--- a/src/public/carriers/manifests/new-manifest.ts
+++ b/src/public/carriers/manifests/new-manifest.ts
@@ -1,5 +1,4 @@
 import type { Address, DateTimeZone } from "../../common";
-import { CustomShippingOptions } from "../types";
 import type { ShipmentIdentifier } from "../shipments/shipment-identifier";
 
 
@@ -35,10 +34,5 @@ export interface NewManifest {
    * All other shipments will be manifested.
    */
   readonly shipments: readonly ShipmentIdentifier[];
-
-  /**
-   * Custom carrier shipping options for creating manifests.
-   */
-  readonly customShippingOptions: CustomShippingOptions;
 
 }

--- a/src/public/carriers/manifests/new-manifest.ts
+++ b/src/public/carriers/manifests/new-manifest.ts
@@ -1,4 +1,5 @@
 import type { Address, DateTimeZone } from "../../common";
+import { CustomShippingOptions } from "../types";
 import type { ShipmentIdentifier } from "../shipments/shipment-identifier";
 
 
@@ -34,4 +35,7 @@ export interface NewManifest {
    * All other shipments will be manifested.
    */
   readonly shipments: readonly ShipmentIdentifier[];
+
+  readonly customShippingOptions: CustomShippingOptions;
+
 }

--- a/src/public/carriers/manifests/new-manifest.ts
+++ b/src/public/carriers/manifests/new-manifest.ts
@@ -36,6 +36,9 @@ export interface NewManifest {
    */
   readonly shipments: readonly ShipmentIdentifier[];
 
+  /**
+   * Custom carrier shipping options for creating manifests.
+   */
   readonly customShippingOptions: CustomShippingOptions;
 
 }

--- a/src/public/carriers/pickups/pickup-request.ts
+++ b/src/public/carriers/pickups/pickup-request.ts
@@ -38,6 +38,9 @@ export interface PickupRequest {
    */
   readonly shipments: readonly PickupShipment[];
   
+  /**
+   * Custom carrier shipping options for scheduling the pickup.
+   */
   readonly customShippingOptions: CustomShippingOptions;
 
 }

--- a/src/public/carriers/pickups/pickup-request.ts
+++ b/src/public/carriers/pickups/pickup-request.ts
@@ -1,4 +1,5 @@
 import type { Address, ContactInfo, Note, TimeRange } from "../../common";
+import { CustomShippingOptions } from "../types";
 import type { PickupService } from "./pickup-service";
 import type { PickupShipment } from "./pickup-shipment";
 
@@ -36,4 +37,7 @@ export interface PickupRequest {
    * The shipments to be picked up
    */
   readonly shipments: readonly PickupShipment[];
+  
+  readonly customShippingOptions: CustomShippingOptions;
+
 }

--- a/src/public/carriers/pickups/pickup-request.ts
+++ b/src/public/carriers/pickups/pickup-request.ts
@@ -1,5 +1,4 @@
 import type { Address, ContactInfo, Note, TimeRange } from "../../common";
-import { CustomShippingOptions } from "../types";
 import type { PickupService } from "./pickup-service";
 import type { PickupShipment } from "./pickup-shipment";
 
@@ -38,9 +37,4 @@ export interface PickupRequest {
    */
   readonly shipments: readonly PickupShipment[];
   
-  /**
-   * Custom carrier shipping options for scheduling the pickup.
-   */
-  readonly customShippingOptions: CustomShippingOptions;
-
 }

--- a/src/public/carriers/rates/rate-criteria.ts
+++ b/src/public/carriers/rates/rate-criteria.ts
@@ -3,7 +3,7 @@ import type { DeliveryService } from "../delivery-service";
 import type { FulfillmentService } from "../fulfillment-service";
 import type { PackageRateCriteria } from "./package-rate-criteria";
 import type { DeliveryConfirmation } from "../delivery-confirmation";
-import { CustomShippingOptions } from "../types";
+import { ShippingOptions } from "../types";
 
 
 /**
@@ -78,6 +78,9 @@ export interface RateCriteria {
    */
   readonly package: PackageRateCriteria;
 
-  readonly customShippingOptions: CustomShippingOptions;
+  /**
+   * Custom carrier shipping options for creating rates.
+   */
+  readonly shippingOptions: ShippingOptions;
 
 }

--- a/src/public/carriers/rates/rate-criteria.ts
+++ b/src/public/carriers/rates/rate-criteria.ts
@@ -3,6 +3,7 @@ import type { DeliveryService } from "../delivery-service";
 import type { FulfillmentService } from "../fulfillment-service";
 import type { PackageRateCriteria } from "./package-rate-criteria";
 import type { DeliveryConfirmation } from "../delivery-confirmation";
+import { CustomShippingOptions } from "../types";
 
 
 /**
@@ -76,4 +77,7 @@ export interface RateCriteria {
    * Useful for carriers that only support single-piece shipments.
    */
   readonly package: PackageRateCriteria;
+
+  readonly customShippingOptions: CustomShippingOptions;
+
 }

--- a/src/public/carriers/shipments/new-shipment.ts
+++ b/src/public/carriers/shipments/new-shipment.ts
@@ -2,6 +2,7 @@ import type { AddressWithContactInfo, DateTimeZone, MonetaryValue } from "../../
 import type { DeliveryService } from "../delivery-service";
 import type { NewPackage } from "../packages/new-package";
 import { DeliveryConfirmation } from "../delivery-confirmation";
+import { CustomShippingOptions } from "../types";
 
 /**
  * The information needed to create a new shipment
@@ -77,4 +78,6 @@ export interface NewShipment {
    * Useful for carriers that only support single-piece shipments.
    */
   readonly package: NewPackage;
+
+  readonly customShippingOptions: CustomShippingOptions;
 }

--- a/src/public/carriers/shipments/new-shipment.ts
+++ b/src/public/carriers/shipments/new-shipment.ts
@@ -80,7 +80,7 @@ export interface NewShipment {
   readonly package: NewPackage;
 
   /**
-   * Custom shipping options for creating rates.
+   * Custom shipping options for creating shipments.
    */
   readonly shippingOptions: ShippingOptions;
 }

--- a/src/public/carriers/shipments/new-shipment.ts
+++ b/src/public/carriers/shipments/new-shipment.ts
@@ -2,7 +2,7 @@ import type { AddressWithContactInfo, DateTimeZone, MonetaryValue } from "../../
 import type { DeliveryService } from "../delivery-service";
 import type { NewPackage } from "../packages/new-package";
 import { DeliveryConfirmation } from "../delivery-confirmation";
-import { CustomShippingOptions } from "../types";
+import { ShippingOptions } from "../types";
 
 /**
  * The information needed to create a new shipment
@@ -82,5 +82,5 @@ export interface NewShipment {
   /**
    * Custom shipping options for creating rates.
    */
-  readonly customShippingOptions: CustomShippingOptions;
+  readonly shippingOptions: ShippingOptions;
 }

--- a/src/public/carriers/shipments/new-shipment.ts
+++ b/src/public/carriers/shipments/new-shipment.ts
@@ -79,5 +79,8 @@ export interface NewShipment {
    */
   readonly package: NewPackage;
 
+  /**
+   * Custom shipping options for creating rates.
+   */
   readonly customShippingOptions: CustomShippingOptions;
 }

--- a/src/public/carriers/types.ts
+++ b/src/public/carriers/types.ts
@@ -4,7 +4,7 @@
  * in the future.
  */
 
-export type CustomShippingOptions = {
+export type ShippingOptions = {
   /**
    * What category of dangerous goods(if any) does the shipment contents contain.
    */

--- a/src/public/carriers/types.ts
+++ b/src/public/carriers/types.ts
@@ -1,0 +1,4 @@
+export type CustomShippingOptions = {
+  dangerousGoodsCategory?: string;
+  billDutiesToSender?: boolean;
+};

--- a/src/public/carriers/types.ts
+++ b/src/public/carriers/types.ts
@@ -1,4 +1,17 @@
+/**
+ * Shipping options that are specific to the carrier. There is currently only 
+ * support for DHL specific shipment options. More universal handling to come 
+ * in the future.
+ */
+
 export type CustomShippingOptions = {
+  /**
+   * What category of dangerous goods(if any) does the shipment contents contain.
+   */
   dangerousGoodsCategory?: string;
+
+  /**
+   * Indicates if the carrier should bill duties to the sender.
+   */
   billDutiesToSender?: boolean;
 };

--- a/src/public/orders/shipments/sales-order-package-item.ts
+++ b/src/public/orders/shipments/sales-order-package-item.ts
@@ -1,4 +1,4 @@
-import type { NotePOJO, Quantity } from "../../common";
+import type { Note, Quantity } from "../../common";
 import type { SalesOrderItemIdentifier } from "../../orders";
 import type { ProductIdentifier } from "../../products";
 
@@ -29,5 +29,5 @@ export interface SalesOrderPackageItem {
   /**
    * Additional notes associated with this notification or its sales order
    */
-  readonly notes?: NotePOJO[];
+  readonly notes?: Note[];
 }

--- a/test/specs/carriers/create-shipment.spec.js
+++ b/test/specs/carriers/create-shipment.spec.js
@@ -242,6 +242,12 @@ describe("createShipment", () => {
       })
     }));
 
+    const newShipment = pojo.newShipment();
+    newShipment.customShippingOptions = {
+      billDutiesToSender: true,
+      dangerousGoodsCategory: "Lithium Metal"
+    }
+
     let confirmation = await app.createShipment(pojo.transaction(), pojo.newShipment());
 
     expect(confirmation).to.deep.equal({
@@ -635,6 +641,26 @@ describe("createShipment", () => {
       catch (error) {
         expect(error.message).to.equal("Invalid input to the createShipment method. Invalid shipment: deliveryService is required, shipFrom must be of type object, shipTo must be of type object, shipDateTime must be one of date, string, object, packages must contain at least 1 items");
       }
+    });
+
+    it("should thrown an error if incorrect custom shipping options are used", async () => {
+      let app = new CarrierApp(pojo.carrierApp({
+        createShipment: () => {}
+      }));
+  
+      const newShipment = pojo.newShipment();
+      newShipment.customShippingOptions = {
+        notSupportedOption: true
+      }
+
+      try {
+        await app.createShipment(pojo.transaction(), newShipment);
+        assert.fail("An error should have been thrown");
+      }
+      catch (error) {
+        expect(error.message).to.equal("Invalid input to the createShipment method. Invalid shipment: customShippingOptions.notSupportedOption is not allowed");
+      }
+  
     });
 
     it("should throw an error if nothing is returned", async () => {

--- a/test/specs/carriers/create-shipment.spec.js
+++ b/test/specs/carriers/create-shipment.spec.js
@@ -243,7 +243,7 @@ describe("createShipment", () => {
     }));
 
     const newShipment = pojo.newShipment();
-    newShipment.customShippingOptions = {
+    newShipment.shippingOptions = {
       billDutiesToSender: true,
       dangerousGoodsCategory: "Lithium Metal"
     }
@@ -649,7 +649,7 @@ describe("createShipment", () => {
       }));
   
       const newShipment = pojo.newShipment();
-      newShipment.customShippingOptions = {
+      newShipment.shippingOptions = {
         notSupportedOption: true
       }
 
@@ -658,7 +658,7 @@ describe("createShipment", () => {
         assert.fail("An error should have been thrown");
       }
       catch (error) {
-        expect(error.message).to.equal("Invalid input to the createShipment method. Invalid shipment: customShippingOptions.notSupportedOption is not allowed");
+        expect(error.message).to.equal("Invalid input to the createShipment method. Invalid shipment: shippingOptions.notSupportedOption is not allowed");
       }
   
     });

--- a/test/specs/carriers/rate-shipment.spec.js
+++ b/test/specs/carriers/rate-shipment.spec.js
@@ -286,7 +286,7 @@ describe("rateShipment", () => {
 
     const rateCritera = pojo.rateCriteria();
 
-    rateCritera.customShippingOptions = {
+    rateCritera.shippingOptions = {
       billDutiesToSender: true,
       dangerousGoodsCategory: "Lithium Metal"
     };
@@ -421,7 +421,7 @@ describe("rateShipment", () => {
       }));
 
       const rateCriteria = pojo.rateCriteria();
-      rateCriteria.customShippingOptions = {
+      rateCriteria.shippingOptions = {
         notSupportedOption: true
       };
 
@@ -430,7 +430,7 @@ describe("rateShipment", () => {
         assert.fail("An error should have been thrown");
       }
       catch (error) {
-        expect(error.message).to.equal("Invalid input to the rateShipment method. Invalid shipment: customShippingOptions.notSupportedOption is not allowed");
+        expect(error.message).to.equal("Invalid input to the rateShipment method. Invalid shipment: shippingOptions.notSupportedOption is not allowed");
       }
     });
     

--- a/test/specs/carriers/rate-shipment.spec.js
+++ b/test/specs/carriers/rate-shipment.spec.js
@@ -286,6 +286,11 @@ describe("rateShipment", () => {
 
     const rateCritera = pojo.rateCriteria();
 
+    rateCritera.customShippingOptions = {
+      billDutiesToSender: true,
+      dangerousGoodsCategory: "Lithium Metal"
+    };
+
     rateCritera.packages[0].customs = {
       contents: [{
         type: "gift",
@@ -409,6 +414,26 @@ describe("rateShipment", () => {
         expect(error.message).to.equal("Invalid input to the rateShipment method. Invalid shipment: deliveryService must be one of object, string, shipDateTime is required, deliveryDateTime must be a valid date/time, shipFrom is required, shipTo is required, packages must contain at least 1 items");
       }
     });
+
+    it("should throw an error if incorrect custom shipping options are used", async () => {
+      let app = new CarrierApp(pojo.carrierApp({
+        rateShipment() { }
+      }));
+
+      const rateCriteria = pojo.rateCriteria();
+      rateCriteria.customShippingOptions = {
+        notSupportedOption: true
+      };
+
+      try {
+        await app.rateShipment(pojo.transaction(), rateCriteria);
+        assert.fail("An error should have been thrown");
+      }
+      catch (error) {
+        expect(error.message).to.equal("Invalid input to the rateShipment method. Invalid shipment: customShippingOptions.notSupportedOption is not allowed");
+      }
+    });
+    
 
     it("should throw an error if nothing is returned", async () => {
       let app = new CarrierApp(pojo.carrierApp({

--- a/test/specs/carriers/schedule-pickup.spec.js
+++ b/test/specs/carriers/schedule-pickup.spec.js
@@ -107,12 +107,6 @@ describe("schedulePickup", () => {
       })
     }));
 
-    const pickupRequest = pojo.pickupRequest();
-    pickupRequest.customShippingOptions = {
-      billDutiesToSender: true,
-      dangerousGoodsCategory: "Lithium Metal"
-    };
-
     let confirmation = await app.schedulePickup(pojo.transaction(), pojo.pickupRequest());
 
     expect(confirmation).to.deep.equal({
@@ -232,27 +226,6 @@ describe("schedulePickup", () => {
       }
       catch (error) {
         expect(error.message).to.equal("Invalid input to the schedulePickup method. Invalid pickup request: A value is required");
-      }
-    });
-
-    it("should throw an error if incorrect custom shipping is used", async () => {
-      let app = new CarrierApp(pojo.carrierApp({
-        pickupServices: [pojo.pickupService()],
-        schedulePickup: () => { }
-      }));
-
-      const pickupRequest = pojo.pickupRequest();
-
-      pickupRequest.customShippingOptions = {
-        notSupportedOption: true
-      }
-
-      try {
-        await app.schedulePickup(pojo.transaction(), pickupRequest);
-        assert.fail("An error should have been thrown");
-      }
-      catch (error) {
-        expect(error.message).to.equal("Invalid input to the schedulePickup method. Invalid pickup request: customShippingOptions.notSupportedOption is not allowed");
       }
     });
 

--- a/test/specs/carriers/schedule-pickup.spec.js
+++ b/test/specs/carriers/schedule-pickup.spec.js
@@ -107,6 +107,12 @@ describe("schedulePickup", () => {
       })
     }));
 
+    const pickupRequest = pojo.pickupRequest();
+    pickupRequest.customShippingOptions = {
+      billDutiesToSender: true,
+      dangerousGoodsCategory: "Lithium Metal"
+    };
+
     let confirmation = await app.schedulePickup(pojo.transaction(), pojo.pickupRequest());
 
     expect(confirmation).to.deep.equal({
@@ -226,6 +232,27 @@ describe("schedulePickup", () => {
       }
       catch (error) {
         expect(error.message).to.equal("Invalid input to the schedulePickup method. Invalid pickup request: A value is required");
+      }
+    });
+
+    it("should throw an error if incorrect custom shipping is used", async () => {
+      let app = new CarrierApp(pojo.carrierApp({
+        pickupServices: [pojo.pickupService()],
+        schedulePickup: () => { }
+      }));
+
+      const pickupRequest = pojo.pickupRequest();
+
+      pickupRequest.customShippingOptions = {
+        notSupportedOption: true
+      }
+
+      try {
+        await app.schedulePickup(pojo.transaction(), pickupRequest);
+        assert.fail("An error should have been thrown");
+      }
+      catch (error) {
+        expect(error.message).to.equal("Invalid input to the schedulePickup method. Invalid pickup request: customShippingOptions.notSupportedOption is not allowed");
       }
     });
 


### PR DESCRIPTION
# Overview

To support the new release of the DHL integration we have added a `customShippingOptions` property to the top level args of the following methods.
* `RateShipment`
* `CreateShipment` 
* `CreateManifest`
* `SchedulePickup`

Rather than being a generic POJO that allows anything we are restricting it to a strict subset that only contains properties needed for the DHL release. 

We will address other carrier's shipping options at a later date with [this Jira task](https://auctane.atlassian.net/browse/DX-652).

