### PR TITLE
POJOs should contain other POJOs when possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect-sdk",
-  "version": "12.5.2",
+  "version": "12.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect-sdk",
-  "version": "12.5.2",
+  "version": "12.5.3",
   "description": "The official SDK for building ShipEngine connect apps",
   "keywords": [
     "shipengine",

--- a/src/internal/orders/requested-fulfillment.ts
+++ b/src/internal/orders/requested-fulfillment.ts
@@ -6,24 +6,24 @@ import { SalesOrderItem } from "./sales-order-item";
 import { ShippingPreferences } from "./shipping-preferences";
 
 export class RequestedFulfillment {
-    public static readonly [_internal] = {
-      label: "requested fulfillment",
-      schema: Joi.object({
-        items: Joi.array().min(1).items(SalesOrderItem[_internal].schema.optional()).required(),
-        shippingPreferences: ShippingPreferences[_internal].schema,
-        shipTo: AddressWithContactInfo[_internal].schema.required(),
-      })
-    };
+  public static readonly [_internal] = {
+    label: "requested fulfillment",
+    schema: Joi.object({
+      items: Joi.array().min(1).items(SalesOrderItem[_internal].schema.optional()).required(),
+      shippingPreferences: ShippingPreferences[_internal].schema,
+      shipTo: AddressWithContactInfo[_internal].schema.required(),
+    })
+  };
 
-    public readonly items: SalesOrderItem[];
-    public readonly shippingPreferences: ShippingPreferences;
-    public readonly shipTo: AddressWithContactInfo;
-    public readonly extensions?: RequestedFulfillmentExtensions;
+  public readonly items: SalesOrderItem[];
+  public readonly shippingPreferences: ShippingPreferences;
+  public readonly shipTo: AddressWithContactInfo;
+  public readonly extensions?: RequestedFulfillmentExtensions;
 
-    public constructor(pojo: RequestedFulfillmentPOJO) {
-        this.items = pojo.items.map((item) => new SalesOrderItem(item)),
-        this.shippingPreferences = new ShippingPreferences(pojo.shippingPreferences || {}),
-        this.shipTo = new AddressWithContactInfo(pojo.shipTo),
-        this.extensions = pojo.extensions
-    }
+  public constructor(pojo: RequestedFulfillmentPOJO) {
+    this.items = pojo.items.map((item) => new SalesOrderItem(item));
+    this.shippingPreferences = new ShippingPreferences(pojo.shippingPreferences || {});
+    this.shipTo = new AddressWithContactInfo(pojo.shipTo);
+    this.extensions = pojo.extensions;
   }
+}

--- a/src/internal/orders/requested-fulfillment.ts
+++ b/src/internal/orders/requested-fulfillment.ts
@@ -21,9 +21,9 @@ export class RequestedFulfillment {
     public readonly extensions?: RequestedFulfillmentExtensions;
 
     public constructor(pojo: RequestedFulfillmentPOJO) {
-      this.items = pojo.items;
-      this.shippingPreferences = pojo.shippingPreferences;
-      this.shipTo = pojo.shipTo;
-      this.extensions = pojo.extensions;
+        this.items = pojo.items.map((item) => new SalesOrderItem(item)),
+        this.shippingPreferences = new ShippingPreferences(pojo.shippingPreferences || {}),
+        this.shipTo = new AddressWithContactInfo(pojo.shipTo),
+        this.extensions = pojo.extensions
     }
   }

--- a/src/internal/orders/sales-order.ts
+++ b/src/internal/orders/sales-order.ts
@@ -59,12 +59,7 @@ export class SalesOrder extends SalesOrderIdentifierBase {
     this.totalCharges = calculateTotalCharges(this.charges);
     
     this.requestedFulfillments = pojo.requestedFulfillments.map((requestedFulfillment) => {
-      return new RequestedFulfillment({
-        items: requestedFulfillment.items.map((item) => new SalesOrderItem(item)),
-        shippingPreferences: new ShippingPreferences(requestedFulfillment.shippingPreferences || {}),
-        shipTo: new AddressWithContactInfo(requestedFulfillment.shipTo),
-        extensions: requestedFulfillment.extensions
-      });
+      return new RequestedFulfillment(requestedFulfillment);
     });
 
     this.notes = pojo.notes || [];

--- a/src/public/orders/requested-fulfillment.ts
+++ b/src/public/orders/requested-fulfillment.ts
@@ -1,4 +1,6 @@
-import { AddressWithContactInfo, SalesOrderItem, ShippingPreferences } from "../../internal";
+import { AddressWithContactInfoPOJO } from "../common/addresses/address-with-contact-info"
+import { SalesOrderItem } from "./sales-order-item"
+import { ShippingPreferences } from "./shipping-preferences"
 
 export interface RequestedFulfillmentExtensions {
     customField1?: string;
@@ -9,6 +11,6 @@ export interface RequestedFulfillmentExtensions {
 export interface RequestedFulfillmentPOJO {
     items: SalesOrderItem[];
     shippingPreferences: ShippingPreferences;
-    shipTo: AddressWithContactInfo;
+    shipTo: AddressWithContactInfoPOJO;
     extensions?: RequestedFulfillmentExtensions;
 }


### PR DESCRIPTION
This fixes a bug where apps were being required to supply fields for `ShippingPreferences` on their orders based on the fields marked as required on the _internal_ version of `ShippingPreferences`, rather than letting them all be optional as specified by the _external_ version of `ShippingPreferences`.