### PR TITLE
PLAT-1528 - add hasCustomMappings to order app definition

### DIFF
--- a/src/internal/orders/order-app.ts
+++ b/src/internal/orders/order-app.ts
@@ -28,7 +28,8 @@ export class OrderApp extends ConnectionApp {
       shipmentCreated: Joi.function(),
       acknowledgeOrders: Joi.function(),
       sendMail: Joi.boolean(),
-      canConfigureTimeZone: Joi.boolean()
+      canConfigureTimeZone: Joi.boolean(),
+      hasCustomMappings: Joi.boolean()
     }),
   };
 
@@ -41,6 +42,7 @@ export class OrderApp extends ConnectionApp {
   public readonly type: AppType;
   public readonly sendMail: boolean;
   public readonly canConfigureTimeZone: boolean;
+  public readonly hasCustomMappings: boolean;
 
 
   public constructor(pojo: OrderAppPOJO) {
@@ -51,6 +53,7 @@ export class OrderApp extends ConnectionApp {
     this.type = AppType.Order;
     this.sendMail = pojo.sendMail || false;
     this.canConfigureTimeZone = pojo.canConfigureTimeZone || false;
+    this.hasCustomMappings = pojo.hasCustomMappings || false;
 
     this[_private] = {
       getSalesOrdersByDate:

--- a/src/public/orders/order-app.ts
+++ b/src/public/orders/order-app.ts
@@ -33,4 +33,9 @@ export interface OrderAppDefinition extends ConnectionAppDefinition {
    * Indicates to show time zone related settings to the user.
    */
   canConfigureTimeZone?: boolean;
+
+    /**
+   * Indicates whether or not the marketplace will override the default sales order status mappings.
+   */
+  hasCustomMappings?: boolean;
 }

--- a/test/specs/orders/order-app.spec.js
+++ b/test/specs/orders/order-app.spec.js
@@ -33,6 +33,7 @@ describe("OrderApp", () => {
       oauthConfig: undefined,
       connectionForm: app.connectionForm,
       sendMail: false,
+      hasCustomMappings: false,
       canConfigureTimeZone: false,
       settingsForm: undefined,
       connect: undefined,
@@ -63,6 +64,7 @@ describe("OrderApp", () => {
       connectionForm: pojo.form(),
       settingsForm: pojo.form(),
       sendMail: true,
+      hasCustomMappings: true,
       canConfigureTimeZone: true,
       connect() { },
       getSalesOrdersByDate() { },
@@ -96,6 +98,7 @@ describe("OrderApp", () => {
       settingsForm: app.settingsForm,
       sdkVersion: parseFloat(sdkManifest.version),
       sendMail: true,
+      hasCustomMappings: true,
       canConfigureTimeZone: true,
       manifest: {
         name: "@my-company/my-order",
@@ -146,6 +149,7 @@ describe("OrderApp", () => {
       acknowledgeOrders: undefined,
       sdkVersion: parseFloat(sdkManifest.version),
       sendMail: false,
+      hasCustomMappings: false,
       canConfigureTimeZone: false,
       manifest: {
         name: "@company/order",


### PR DESCRIPTION
Per AC for: https://auctane.atlassian.net/browse/PLAT-1528 ("Data Driven Marketplace Modals should accept custom status mappings"):

> Order apps have a boolean in the metadata for HasCustomMappings which is sent to the registry

This PR adds the `hasCustomMappings` boolean to Order App Definition

Tests performed:

`npm run-script build && npm run-script test`