### PR TITLE
Updated regex.appName to a new regex that tests for valid npm scope a…

### DIFF
--- a/src/internal/common/utils.ts
+++ b/src/internal/common/utils.ts
@@ -10,7 +10,7 @@ export const _internal = Symbol("internal fields");
 export const regex = {
   isoDateTime: /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([+-]\d{2}:\d{2}|Z)?$/,
   utcOffset: /^[+-]([01][0-9]|2[0-3]):[0-5][0-9]$/,
-  appName: /^@[a-z][a-z0-9]*(-[a-z0-9]+)*\/[a-z][a-z0-9]*(-[a-z0-9]+)*$/,
+  appName: /^(@[a-z0-9-~][a-z0-9-._~]*\/)[a-z0-9-~][a-z0-9-._~]*$/,
   semver: /^\d+\.\d+\.\d+/,
   money: /^-?\d+(\.\d+)?$/,
   protocol: /^https?:\/\//,

--- a/test/specs/common/app.spec.js
+++ b/test/specs/common/app.spec.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { CarrierApp } = require("../../../lib/internal");
+const { regex } = require("../../../lib/internal/common/utils");
 const sdkManifest = require("../../../package.json");
 const pojo = require("../../utils/pojo");
 const { expect } = require("chai");
@@ -100,6 +101,11 @@ describe("App", () => {
     });
   });
 
+  it("should allow all possible valid characters for NPM scope and NPM package name", () => {
+    let npmScopeAndPackageName = "@company-name~test_se.connect/app-name_connect~carrier.app";
+    expect(npmScopeAndPackageName).to.match(regex.appName);
+  });
+
   describe("Failure tests", () => {
 
     it("should throw an error if the pojo is the wrong type", () => {
@@ -145,6 +151,11 @@ describe("App", () => {
         },
       }))
       ).to.throw('Invalid ShipEngine Connect carrier app: manifest.description must be a string');
+    });
+
+    it("should not allow any invalid characters for NPM scope and NPM package name", () => {
+      let npmScopeAndPackageName = "@Company$Name|carrier*app/app,name+shipEngine";
+      expect(npmScopeAndPackageName).to.not.match(regex.appName);
     });
 
   });


### PR DESCRIPTION
…nd npm package name, including underscores fixing the error that is thrown when an underscore is explicitly provided in the app name.

I was going to use a package called `package-name-regex` but the regex that this package exports uses the `?` regex quantifier which matches between 0 and 1 times. This would allow a non-scoped npm package to still match and pass the regex test since it allows matching 0 times with the `?` quantifier.

I ended up not using the package and using the regex the package contains and removed the `?` quantifier, as the package itself doesn't give you a way to do so.

- Link to the package itself - [NPM: package-name-regex](https://www.npmjs.com/package/package-name-regex "NPM package-name-regex")
- Index.js that exports the unmodified regex that matches npm scope and npm package names, per npm package requirements. [package-name-regex - index.js:](https://github.com/dword-design/package-name-regex/blob/802c9e3ab6928dee3309a332c436fedc942ed346/src/index.js#L1 "package-name-regex index.js")