### PR TITLE
DX-689 Order app mappings

### DIFF
--- a/src/internal/common/transaction.ts
+++ b/src/internal/common/transaction.ts
@@ -4,19 +4,10 @@ import { Joi, validate } from "./validation";
 
 const _private = Symbol("private fields");
 
-export type SessionPOJO<T extends object = object> = T & {
-  readonly auth?: {
-    readonly username?: string;
-    readonly password?: string;
-    readonly accessToken?: string;
-    readonly apiKey?: string;
-  }
-}
-
 export interface TransactionPOJO<T extends object = object> {
   id: UUID;
   language: string;
-  session?: SessionPOJO<T>;
+  session?: T;
 }
 
 export class Transaction<T extends object = object> implements ITransaction {
@@ -30,19 +21,19 @@ export class Transaction<T extends object = object> implements ITransaction {
   };
 
   private readonly [_private]: {
-    session: SessionPOJO<T>;
+    session: T;
   };
 
   public readonly id: UUID;
   public readonly language: string;
 
-  public get session(): SessionPOJO<T> {
+  public get session(): T {
     return this[_private].session;
   }
 
-  public set session(value: SessionPOJO<T>) {
+  public set session(value: T) {
     if (value === undefined) {
-      value = {} as unknown as SessionPOJO<T>;
+      value = {} as unknown as T;
     }
 
     validate(value, "session data", Joi.object());

--- a/src/internal/orders/index.ts
+++ b/src/internal/orders/index.ts
@@ -16,3 +16,4 @@ export * from "./sales-order-paging";
 export * from "./requested-fulfillment";
 export * from "./original-order-source";
 export * from "./sales-order-custom-field-mapping";
+export * from "./sales-order-transaction";

--- a/src/internal/orders/order-app.ts
+++ b/src/internal/orders/order-app.ts
@@ -1,8 +1,9 @@
 import { AcknowledgeOrders, AppType, Connect, ErrorCode, GetSalesOrdersByDate, OrderAppDefinition, SalesOrders as SalesOrdersPOJO, ShipmentCreated } from "../../public";
-import { AppPOJO, ConnectionApp, error, FormPOJO, hideAndFreeze, Joi, SystemErrorCode, Transaction, TransactionPOJO, validate, _internal, OAuthConfigPOJO } from "../common";
+import { AppPOJO, ConnectionApp, error, FormPOJO, hideAndFreeze, Joi, SystemErrorCode, Transaction, validate, _internal, OAuthConfigPOJO } from "../common";
 import { AcknowledgedSalesOrder } from "./acknowledged-sales-order";
 import { SalesOrderNotification, SalesOrderNotificationPOJO } from "./sales-order-notification";
 import { SalesOrderTimeRange, SalesOrderTimeRangePOJO } from "./sales-order-time-range";
+import { SalesOrderTransaction, SalesOrderTransactionPOJO } from "./sales-order-transaction";
 import { SalesOrders } from "./sales-orders";
 import { SalesOrderShipment, SalesOrderShipmentPOJO } from "./shipments/sales-order-shipment";
 
@@ -67,13 +68,13 @@ export class OrderApp extends ConnectionApp {
   }
 
   public async getSalesOrdersByDate?(
-    transaction: TransactionPOJO, range: SalesOrderTimeRangePOJO): Promise<SalesOrders> {
+    transaction: SalesOrderTransactionPOJO, range: SalesOrderTimeRangePOJO): Promise<SalesOrders> {
 
     let _transaction, _range;
     const { getSalesOrdersByDate } = this[_private];
 
     try {
-      _transaction = new Transaction(validate(transaction, Transaction));
+      _transaction = new SalesOrderTransaction(validate(transaction, SalesOrderTransaction));
       _range = new SalesOrderTimeRange(validate(range, SalesOrderTimeRange));
     }
     catch (originalError: unknown) {
@@ -97,12 +98,12 @@ export class OrderApp extends ConnectionApp {
     }
   }
 
-  public async shipmentCreated?(transaction: TransactionPOJO, shipment: SalesOrderShipmentPOJO): Promise<void> {
+  public async shipmentCreated?(transaction: SalesOrderTransactionPOJO, shipment: SalesOrderShipmentPOJO): Promise<void> {
     let _transaction, _shipment;
     const { shipmentCreated } = this[_private];
 
     try {
-      _transaction = new Transaction(validate(transaction, Transaction));
+      _transaction = new SalesOrderTransaction(validate(transaction, SalesOrderTransaction));
       _shipment = new SalesOrderShipment(validate(shipment, SalesOrderShipment));
     }
     catch (originalError: unknown) {
@@ -118,13 +119,13 @@ export class OrderApp extends ConnectionApp {
     }
   }
 
-  public async acknowledgeOrders?(transaction: TransactionPOJO, notifications: SalesOrderNotificationPOJO[]): Promise<AcknowledgedSalesOrder[]> {
+  public async acknowledgeOrders?(transaction: SalesOrderTransactionPOJO, notifications: SalesOrderNotificationPOJO[]): Promise<AcknowledgedSalesOrder[]> {
     let _transaction;
     const _notifications: SalesOrderNotification[] = [];
     const { acknowledgeOrders } = this[_private];
 
     try {
-      _transaction = new Transaction(validate(transaction, Transaction));
+      _transaction = new SalesOrderTransaction(validate(transaction, SalesOrderTransaction));
 
       if (notifications.length === 0) {
         throw error(SystemErrorCode.InvalidInput, "Sales Order Notifications are required");

--- a/src/internal/orders/sales-order-time-range.ts
+++ b/src/internal/orders/sales-order-time-range.ts
@@ -1,30 +1,20 @@
-import Joi = require("joi");
 import {
   SalesOrderPaging as SalesOrderPagingPOJO,
-  SalesOrderStatus,
   SalesOrderTimeRange as ISalesOrderTimeRange,
-  TimeRangePOJO,
-  SalesOrderCustomFieldMappingPOJO
+  TimeRangePOJO
 } from "../../public";
 import { hideAndFreeze, TimeRange, TimeRangeBase, _internal } from "../common";
 import { SalesOrderPaging } from "./sales-order-paging";
-import { SalesOrderCustomFieldMapping } from "./sales-order-custom-field-mapping";
 
 export interface SalesOrderTimeRangePOJO extends TimeRangePOJO {	
   paging?: SalesOrderPagingPOJO;	
-  statusMappings?: {	
-    [key: string]: SalesOrderStatus;	
-  };	
-  fieldMappings?: SalesOrderCustomFieldMappingPOJO;
 }
 
 export class SalesOrderTimeRange extends TimeRangeBase implements ISalesOrderTimeRange {
   public static readonly [_internal] = {
     label: "time range",
     schema: TimeRange[_internal].schema.keys({
-      paging: SalesOrderPaging[_internal].schema,
-      statusMappings: Joi.object().optional(),
-      fieldMappings: Joi.object().optional(),
+      paging: SalesOrderPaging[_internal].schema
     })
   };
 
@@ -37,21 +27,12 @@ export class SalesOrderTimeRange extends TimeRangeBase implements ISalesOrderTim
     readonly cursor?: string;
   };
 
-  public readonly statusMappings?: Readonly<{
-    [key: string]: SalesOrderStatus;
-  }>;
-
-  public readonly fieldMappings?: Readonly<SalesOrderCustomFieldMapping>;
-
   public constructor(pojo: SalesOrderTimeRangePOJO) {
     super(pojo);
 
     if (pojo.paging) {
       this.paging = new SalesOrderPaging(pojo.paging);
     }
-
-    this.statusMappings = pojo.statusMappings;
-    this.fieldMappings = pojo.fieldMappings && new SalesOrderCustomFieldMapping(pojo.fieldMappings)
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/src/internal/orders/sales-order-transaction.ts
+++ b/src/internal/orders/sales-order-transaction.ts
@@ -1,0 +1,79 @@
+import { SalesOrderStatus, SalesOrderCustomFieldMappingPOJO } from "../../public"
+import { Transaction, TransactionPOJO } from "../common/transaction"
+import { _internal } from "../common/utils";
+import { Joi, validate } from "../common/validation";
+import { SalesOrderCustomFieldMapping } from "./sales-order-custom-field-mapping";
+
+export type SalesOrderSessionPOJO<T extends object = object> = T & {
+  readonly auth?: {
+    readonly username?: string;
+    readonly password?: string;
+    readonly accessToken?: string;
+    readonly apiKey?: string;
+  }
+}
+
+const _private = Symbol("private fields");
+
+export interface SalesOrderTransactionPOJO<T extends object = object> extends TransactionPOJO {
+  session?: SalesOrderSessionPOJO<T>;
+  statusMappings?: {	
+    [key: string]: SalesOrderStatus;	
+  };	
+  fieldMappings?: SalesOrderCustomFieldMappingPOJO;
+}
+
+export class SalesOrderTransaction<T extends object = object> extends Transaction<T> {
+  public static readonly [_internal] = {
+    label: "transaction",
+    schema: Joi.object({
+      id: Joi.string().uuid().required(),
+      language: Joi.string().required(),
+      session: Joi.object(),
+      statusMappings: Joi.object().optional(),
+      fieldMappings: Joi.object().optional(),
+    }),
+  };
+
+  private readonly [_private]: {
+    session: SalesOrderSessionPOJO<T>;
+  };
+
+  public get session(): SalesOrderSessionPOJO<T> {
+    return this[_private].session;
+  }
+
+  public set session(value: SalesOrderSessionPOJO<T>) {
+    if (value === undefined) {
+      value = {} as unknown as T;
+    }
+
+    validate(value, "session data", Joi.object());
+
+    const session = this[_private].session as Record<string, unknown>;
+    const keys = Object.getOwnPropertyNames(session).concat(Object.getOwnPropertyNames(value));
+
+    for (const key of keys) {
+      if (key in value) {
+        session[key] = (value as Record<string, unknown>)[key];
+      }
+      else {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete session[key];
+      }
+    }
+  }
+
+  public readonly statusMappings?: Readonly<{
+    [key: string]: SalesOrderStatus;
+  }>;
+
+  public readonly fieldMappings?: Readonly<SalesOrderCustomFieldMapping>;
+
+  public constructor(pojo: SalesOrderTransactionPOJO<T>) {
+    super(pojo);
+
+    this.statusMappings = pojo.statusMappings;
+    this.fieldMappings = pojo.fieldMappings && new SalesOrderCustomFieldMapping(pojo.fieldMappings)
+  }
+}

--- a/src/public/common/transaction.ts
+++ b/src/public/common/transaction.ts
@@ -1,8 +1,8 @@
 import type { UUID } from "./types";
 
 /**
- * The ShpEngine Connect passes this object to every method call. It provides information about the
- * transaction being performed, including authentication, metadata, etc.
+ * The ShipEngine Connect passes this object to every method call. It provides information about the
+ * transaction being performed, including authentication, configuration, metadata, etc.
  */
 export interface Transaction<T extends object = object> {
   /**

--- a/src/public/common/transaction.ts
+++ b/src/public/common/transaction.ts
@@ -1,39 +1,6 @@
 import type { UUID } from "./types";
 
 /**
- * Session data that may include auth data set by a data driven auth processes.
- * May include arbitrary data set by the developer.
- * Must be JSON serializable. Any method may update the session data,
- * such as renewing a session token or updating a timestamp.
- */
-export type Session<T extends object = object> = T & {
-  /**
-  * Auth object set by a data driven auth processes.
-  */
-  readonly auth?: {
-    /**
-     * Populated by the data driven auth processes for basic auth integrations.
-     */
-    readonly username?: string;
-
-    /**
-     * Populated by the data driven auth processes for basic auth integrations.
-     */
-    readonly password?: string;
-
-    /**
-     * Populated by the data driven auth processes for OAuth integrations.
-     */
-    readonly accessToken?: string;
-
-    /**
-     * Populated by the data driven auth processes for API Key integrations.
-     */
-    readonly apiKey?: string;
-  }
-}
-
-/**
  * The ShpEngine Connect passes this object to every method call. It provides information about the
  * transaction being performed, including authentication, metadata, etc.
  */
@@ -56,5 +23,5 @@ export interface Transaction<T extends object = object> {
    * Must be JSON serializable. Any method may update the session data,
    * such as renewing a session token or updating a timestamp.
    */
-  session: Session<T>;
+  session: T;
 }

--- a/src/public/orders/index.ts
+++ b/src/public/orders/index.ts
@@ -10,6 +10,7 @@ export * from "./sales-order-identifier";
 export * from "./sales-order-item";
 export * from "./sales-order-item-identifier";
 export * from "./sales-order-time-range";
+export * from "./sales-order-transaction";
 export * from "./shipments/sales-order-package-item";
 export * from "./shipments/sales-order-shipment";
 export * from "./shipping-preferences";

--- a/src/public/orders/methods.ts
+++ b/src/public/orders/methods.ts
@@ -1,14 +1,14 @@
-import type { Transaction } from "../common";
 import { SalesOrders } from "./sales-orders";
 import { SalesOrderShipment } from "./shipments/sales-order-shipment";
 import { SalesOrderNotification } from "./sales-order-notification";
+import { SalesOrderTransaction } from "./sales-order-transaction";
 import { AcknowledgedSalesOrder } from "./acknowledged-sales-order";
 import { SalesOrderTimeRange } from "./sales-order-time-range";
 
 /**
  * Returns all orders that were created and/or modified within a given timeframe
  */
-export type GetSalesOrdersByDate = (transaction: Transaction, range: SalesOrderTimeRange)
+export type GetSalesOrdersByDate = (transaction: SalesOrderTransaction, range: SalesOrderTimeRange)
 => SalesOrders | Promise<SalesOrders>;
 
 /**
@@ -17,12 +17,12 @@ export type GetSalesOrdersByDate = (transaction: Transaction, range: SalesOrderT
  * A single shipment may contain items from multiple sales orders, and a single sales order
  * may be fulfilled by multiple shipments.
  */
-export type ShipmentCreated = (transaction: Transaction, shipment: SalesOrderShipment)
+export type ShipmentCreated = (transaction: SalesOrderTransaction, shipment: SalesOrderShipment)
 => void | Promise<void>;
 
 
 /**
  * Called when an order has been imported into a marketplace.
  */
-export type AcknowledgeOrders = (transaction: Transaction, notifications: SalesOrderNotification[])
+export type AcknowledgeOrders = (transaction: SalesOrderTransaction, notifications: SalesOrderNotification[])
 => AcknowledgedSalesOrder[] | Promise<AcknowledgedSalesOrder[]>;

--- a/src/public/orders/sales-order-time-range.ts
+++ b/src/public/orders/sales-order-time-range.ts
@@ -1,4 +1,3 @@
-import { SalesOrderStatus } from ".";
 import type { TimeRange } from "../common";
 
 
@@ -7,21 +6,6 @@ import type { TimeRange } from "../common";
  */
 export interface SalesOrderTimeRange extends TimeRange {
   readonly paging?: Readonly<SalesOrderPaging>;
-
-  /**
-   * A mapping of custom user-defined statuses to ShipEngine Connect statuses.
-   * 
-   * Each key is a user-defined status string, and the value is the corresponding
-   * ShipEngine Connect order status.
-   */
-  readonly statusMappings?: Readonly<{
-    [key: string]: SalesOrderStatus;
-  }>;
-
-  /**
-   * A mapping custom user-defined fields to RequestedFulfillmentExtensions
-   */
-  readonly fieldMappings?: Readonly<SalesOrderCustomFieldMappingPOJO>;
 }
 
 export interface SalesOrderPaging {
@@ -56,5 +40,5 @@ export interface SalesOrderPagingPOJO {
 export interface SalesOrderCustomFieldMappingPOJO {
   customField1?: string;
   customField2?: string;
-  customField3?: string; 
+  customField3?: string;
 }

--- a/src/public/orders/sales-order-transaction.ts
+++ b/src/public/orders/sales-order-transaction.ts
@@ -36,8 +36,8 @@ export type SalesOrderSession<T extends object = object> = T & {
 }
 
 /**
- * The ShpEngine Connect passes this object to every method call. It provides information about the
- * transaction being performed, including authentication, metadata, etc.
+ * The ShipEngine Connect passes this object to every method call. It provides information about the
+ * transaction being performed, including authentication, configuration, metadata, etc.
  */
 export interface SalesOrderTransaction<T extends object = object> extends Transaction<T> {
   /**

--- a/src/public/orders/sales-order-transaction.ts
+++ b/src/public/orders/sales-order-transaction.ts
@@ -1,0 +1,48 @@
+import { Transaction } from "../common";
+
+/**
+ * Session data that may include auth data set by a data driven auth processes.
+ * May include arbitrary data set by the developer.
+ * Must be JSON serializable. Any method may update the session data,
+ * such as renewing a session token or updating a timestamp.
+ */
+export type SalesOrderSession<T extends object = object> = T & {
+  /**
+  * Auth object set by a data driven auth processes.
+  */
+  readonly auth?: {
+    /**
+     * Populated by the data driven auth processes for basic auth integrations.
+     */
+    readonly username?: string;
+
+    /**
+     * Populated by the data driven auth processes for basic auth integrations.
+     */
+    readonly password?: string;
+
+    /**
+     * Populated by the data driven auth processes for OAuth integrations.
+     */
+    readonly accessToken?: string;
+
+    /**
+     * Populated by the data driven auth processes for API Key integrations.
+     */
+    readonly apiKey?: string;
+  }
+}
+
+/**
+ * The ShpEngine Connect passes this object to every method call. It provides information about the
+ * transaction being performed, including authentication, metadata, etc.
+ */
+export interface SalesOrderTransaction<T extends object = object> extends Transaction<T> {
+  /**
+   * Session data that may include auth data set by a data driven auth processes.
+   * May include arbitrary data set by the developer.
+   * Must be JSON serializable. Any method may update the session data,
+   * such as renewing a session token or updating a timestamp.
+   */
+  session: SalesOrderSession<T>;
+}

--- a/src/public/orders/sales-order-transaction.ts
+++ b/src/public/orders/sales-order-transaction.ts
@@ -1,4 +1,6 @@
 import { Transaction } from "../common";
+import { SalesOrderStatus } from "./enums";
+import { SalesOrderCustomFieldMappingPOJO } from "./sales-order-time-range";
 
 /**
  * Session data that may include auth data set by a data driven auth processes.
@@ -45,4 +47,19 @@ export interface SalesOrderTransaction<T extends object = object> extends Transa
    * such as renewing a session token or updating a timestamp.
    */
   session: SalesOrderSession<T>;
+
+  /**
+   * A mapping of custom user-defined statuses to ShipEngine Connect statuses.
+   *
+   * Each key is a user-defined status string, and the value is the corresponding
+   * ShipEngine Connect order status.
+   */
+  readonly statusMappings?: Readonly<{
+    [key: string]: SalesOrderStatus;
+  }>;
+
+  /**
+   * A mapping custom user-defined fields to RequestedFulfillmentExtensions
+   */
+  readonly fieldMappings?: Readonly<SalesOrderCustomFieldMappingPOJO>;
 }

--- a/test/specs/orders/get-sales-orders-by-date.spec.js
+++ b/test/specs/orders/get-sales-orders-by-date.spec.js
@@ -92,13 +92,9 @@ describe("getSalesOrdersByDate", () => {
     }));
 
     const timeRange = pojo.timeRange();
+    const transaction = pojo.transaction({statusMappings: { foo: "bar", bar: "baz"}})
 
-    timeRange.statusMappings = {
-      "customStatus1": "awaiting_payment",
-      "customStatus2": "on_hold"
-    }
-
-    let response = await app.getSalesOrdersByDate(pojo.transaction(), timeRange);
+    let response = await app.getSalesOrdersByDate(transaction, timeRange);
 
     // The sales orders should be returned in order
     let index = 0;


### PR DESCRIPTION
We had added fields to the base `Transaction` and `Session` objects that were only applicable to Order Apps, so I moved those to new types named `SalesOrderTransaction` and `SalesOrderSession` so we don't pollute Carrier Apps.

Similarly, I also moved custom mapping fields from the `SalesOrderTimeRange` object to the new `SalesOrderTransaction` object.
